### PR TITLE
fix: move last_message contact update to background queue

### DIFF
--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -131,21 +131,45 @@ def last_message(doc, method):
     else:
         mobile_no = doc.get("from")
 
-    mobile_no = mobile_no[-10:]
+    if not mobile_no:
+        frappe.log_error(
+            title="WhatsApp Contact Update Skipped - Missing Mobile Number",
+            message=(
+                f"A WhatsApp message (ID: {doc.name}) was received but has no mobile number.\n\n"
+                f"Message Type : {doc.type}\n"
+                f"From         : {doc.get('from') or 'Not provided'}\n"
+                f"To           : {doc.to or 'Not provided'}\n\n"
+                "Action Taken : Contact update was skipped. Please check this message manually in WhatsApp Message list."
+            ),
+        )
+        return
 
+    frappe.enqueue(
+        "whatsapp_chat.api.message.update_contact_on_message",
+        queue="default",
+        mobile_no=mobile_no[-10:],
+        message=doc.message,
+        message_type=doc.type,
+        profile_name=doc.get("profile_name"),
+        is_outgoing=doc.type == "Outgoing",
+    )
+
+
+def update_contact_on_message(mobile_no, message, message_type, profile_name, is_outgoing):
     contact_name = frappe.db.get_value(
         "WhatsApp Contact",
-        filters={"mobile_no": ["like", f"%{mobile_no}"]},
+        filters={"mobile_no": ["like", f"%{mobile_no}"]},  
         order_by="modified desc",
     )
     if contact_name:
         chat_doc = frappe.get_doc("WhatsApp Contact", contact_name)
-        chat_doc.last_message = doc.message
-        chat_doc.is_read = 0
-        chat_doc.message_type = doc.type
-        if chat_doc.contact_name[-10:] == mobile_no and doc.get("profile_name"):
-            chat_doc.contact_name = doc.get("profile_name")
-        if doc.type == "Outgoing":
+        chat_doc.last_message = message
+        chat_doc.message_type = message_type
+        if not is_outgoing:
+            chat_doc.is_read = 0
+        if chat_doc.contact_name[-10:] == mobile_no and profile_name:
+            chat_doc.contact_name = profile_name
+        if is_outgoing:
             chat_doc.db_update()
         else:
             chat_doc.save(ignore_permissions=True)
@@ -154,23 +178,21 @@ def last_message(doc, method):
             {
                 "doctype": "WhatsApp Contact",
                 "mobile_no": mobile_no,
-                "last_message": doc.message,
-                "contact_name": doc.get("profile_name") or mobile_no,
-                "message_type": doc.type,
+                "last_message": message,
+                "contact_name": profile_name or mobile_no,
+                "message_type": message_type,
                 "is_read": 0,
             }
         )
         chat_doc.insert(ignore_permissions=True)
 
-    if chat_doc.email and doc.type != "Outgoing":
+    if chat_doc.email and not is_outgoing:
         frappe.publish_realtime(
             "latest_chat_updates",
             {
-                "content": doc.message,
+                "content": message,
                 "creation": frappe.utils.now(),
                 "room": chat_doc.name,
             },
             user=chat_doc.email,
         )
-
-    return "ok"

--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -167,7 +167,8 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
         chat_doc.message_type = message_type
         if not is_outgoing:
             chat_doc.is_read = 0
-        if chat_doc.contact_name[-10:] == mobile_no and profile_name:
+        current_contact_name = chat_doc.contact_name or ""
+        if current_contact_name[-10:] == mobile_no and profile_name:
             chat_doc.contact_name = profile_name
         if is_outgoing:
             chat_doc.db_update()


### PR DESCRIPTION
- Add null-guard for missing mobile number with descriptive error log instead of silently crashing on mobile_no[-10:] when mobile_no is None
- Extract contact-update logic into update_contact_on_message() and enqueue it via frappe.enqueue so the after_insert hook returns immediately, preventing slow WhatsApp Contact saves from blocking the main worker thread
- Fix is_read flag: only set to 0 for Incoming messages; Outgoing messages already used db_update() but was incorrectly resetting is_read
- Remove unused return value ("ok") from the now-extracted function