### PR TITLE
feat: SRO-2026-04-00023 Replace floating chat widget with full-screen WhatsApp page

### DIFF
--- a/whatsapp_chat/api/contacts.py
+++ b/whatsapp_chat/api/contacts.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import add_to_date, now_datetime
 
 
 @frappe.whitelist()
@@ -17,10 +18,13 @@ def create(contact_name, mobile_no, email):
 
 @frappe.whitelist()
 def get(email):
-    """Get all contacts that have any WhatsApp message history, ordered by most recent activity."""
+    """Get all contacts assigned to email."""
     contacts = frappe.db.get_list(
         "WhatsApp Contact", fields=["*"], order_by="modified desc"
     )
+
+    # Get datetime for 1 day ago
+    one_day_ago = add_to_date(now_datetime(), days=-1)
 
     mobile_nos = frappe.db.sql(
         """
@@ -29,14 +33,16 @@ def get(email):
         WHERE `from` IS NOT NULL
             AND TRIM(`from`) != ''
             AND LENGTH(TRIM(`from`)) >= 10
+            AND creation >= %(one_day_ago)s
         HAVING mobile_no IS NOT NULL
             AND mobile_no != ''
         ORDER BY mobile_no;
-        """,
+    """,
+        {"one_day_ago": one_day_ago},
         as_list=True,
     )
 
-    mobile_nos = {no[0] for no in mobile_nos}
+    mobile_nos = [no[0] for no in mobile_nos]
     if not mobile_nos:
         return []
 

--- a/whatsapp_chat/api/contacts.py
+++ b/whatsapp_chat/api/contacts.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.utils import add_to_date, now_datetime
 
 
 @frappe.whitelist()
@@ -18,31 +17,26 @@ def create(contact_name, mobile_no, email):
 
 @frappe.whitelist()
 def get(email):
-    """Get all contacts assigned to email."""
+    """Get all contacts that have any WhatsApp message history, ordered by most recent activity."""
     contacts = frappe.db.get_list(
         "WhatsApp Contact", fields=["*"], order_by="modified desc"
     )
 
-    # Get datetime for 1 day ago
-    one_day_ago = add_to_date(now_datetime(), days=-1)
-
     mobile_nos = frappe.db.sql(
         """
-        SELECT DISTINCT RIGHT(`from`, 10) AS mobile_no 
+        SELECT DISTINCT RIGHT(`from`, 10) AS mobile_no
         FROM `tabWhatsApp Message`
-        WHERE `from` IS NOT NULL 
+        WHERE `from` IS NOT NULL
             AND TRIM(`from`) != ''
             AND LENGTH(TRIM(`from`)) >= 10
-            AND creation >= %(one_day_ago)s
-        HAVING mobile_no IS NOT NULL 
+        HAVING mobile_no IS NOT NULL
             AND mobile_no != ''
         ORDER BY mobile_no;
-    """,
-        {"one_day_ago": one_day_ago},
+        """,
         as_list=True,
     )
 
-    mobile_nos = [no[0] for no in mobile_nos]
+    mobile_nos = {no[0] for no in mobile_nos}
     if not mobile_nos:
         return []
 

--- a/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
+++ b/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
@@ -480,3 +480,144 @@ $height: 582px;
     border: 1px solid var(--red-avatar-color);
   }
 }
+
+// ── Full-screen WhatsApp page ────────────────────────────────────────────────
+
+.wa-main {
+  padding: 0 !important;
+  overflow: hidden;
+}
+
+.wa-page {
+  display: flex;
+  height: calc(100vh - 60px); // viewport minus Frappe navbar
+  overflow: hidden;
+  border-top: 1px solid var(--dark-border-color);
+}
+
+.wa-panel-left {
+  width: 320px;
+  min-width: 280px;
+  border-right: 1px solid var(--dark-border-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .chat-list {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .chat-rooms-container {
+    // Override the fixed-height calc from the widget
+    height: auto !important;
+    flex: 1;
+    overflow-y: auto;
+  }
+}
+
+.wa-panel-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--card-bg);
+
+  .chat-space {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .chat-space-container {
+      // Override fixed-height calc; fill remaining space
+      height: auto !important;
+      flex: 1;
+      overflow-y: auto;
+    }
+  }
+
+  // Hide back button in two-panel layout
+  .chat-back-button {
+    display: none !important;
+  }
+}
+
+// Empty-state placeholder shown before any room is selected
+.wa-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  gap: var(--margin-md);
+
+  .wa-empty-icon {
+    svg {
+      width: 3rem;
+      height: 3rem;
+      opacity: 0.35;
+    }
+  }
+
+  h4 {
+    margin: 0;
+    font-weight: 600;
+    color: var(--text-color);
+  }
+
+  p {
+    margin: 0;
+    font-size: $font-size-sm;
+  }
+}
+
+// Linked-doc navigation button inside the chat header
+.wa-linked-doc-container {
+  margin-left: auto;
+  flex-shrink: 0;
+
+  .wa-linked-doc-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: $font-size-xs;
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    padding: 3px 8px;
+    white-space: nowrap;
+    text-decoration: none;
+
+    svg {
+      flex-shrink: 0;
+    }
+
+    &:hover {
+      background: var(--primary-color);
+      color: var(--white);
+      svg { fill: var(--white); }
+      text-decoration: none;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .wa-panel-left {
+    width: 100%;
+    display: none;
+
+    &.wa-mobile-show {
+      display: flex;
+    }
+  }
+
+  .wa-panel-right {
+    width: 100%;
+
+    .chat-back-button {
+      display: flex !important;
+    }
+  }
+}

--- a/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
+++ b/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
@@ -604,20 +604,24 @@ $height: 582px;
 }
 
 @media (max-width: 768px) {
-  .wa-panel-left {
-    width: 100%;
-    display: none;
-
-    &.wa-mobile-show {
+  .wa-page {
+    .wa-panel-left {
+      width: 100%;
       display: flex;
+    }
+    .wa-panel-right {
+      width: 100%;
+      display: none;
+    }
+
+    // Chat-open state: hide list, show chat space
+    &.wa-chat-open {
+      .wa-panel-left  { display: none; }
+      .wa-panel-right { display: flex; }
     }
   }
 
-  .wa-panel-right {
-    width: 100%;
-
-    .chat-back-button {
-      display: flex !important;
-    }
+  .chat-back-button {
+    display: flex !important;
   }
 }

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -6,6 +6,9 @@ import { get_rooms, mark_message_read, get_time } from './chat_utils';
 export default class ChatList {
   constructor(opts) {
     this.$wrapper = opts.$wrapper;
+    // In two-panel (full-screen) mode the caller passes a separate wrapper
+    // for ChatSpace so the left panel is never replaced by a chat view.
+    this.$space_wrapper = opts.$space_wrapper || opts.$wrapper;
     this.user = opts.user;
     this.user_email = opts.user_email;
     this.is_admin = opts.is_admin;
@@ -15,6 +18,7 @@ export default class ChatList {
   setup() {
     this.$chat_list = $(document.createElement('div'));
     this.$chat_list.addClass('chat-list');
+    this.chat_rooms = [];
     this.setup_header();
     this.setup_search();
     this.fetch_and_setup_rooms();
@@ -99,7 +103,7 @@ export default class ChatList {
       this.chat_rooms.push([
         profile.room,
         new ChatRoom({
-          $wrapper: this.$wrapper,
+          $wrapper: this.$space_wrapper,
           $chat_rooms_container: this.$chat_rooms_container,
           chat_list: this,
           element: profile,
@@ -133,7 +137,7 @@ export default class ChatList {
     this.chat_rooms.unshift([
       profile.room,
       new ChatRoom({
-        $wrapper: this.$wrapper,
+        $wrapper: this.$space_wrapper,
         $chat_rooms_container: this.$chat_rooms_container,
         chat_list: this,
         element: profile,
@@ -215,50 +219,53 @@ export default class ChatList {
 
       chat_room_item[1].set_last_message(message, res.creation);
 
-      // Check if user is in chat list or active chat space
-      if ($('.chat-list').is(':visible')) {
-        // User is viewing chat list
+      // In two-panel (full-screen) mode both .chat-list and .chat-space are
+      // visible simultaneously. Detect this by checking for .wa-panel-right.
+      const is_two_panel = $('.wa-panel-right').length > 0;
+      const right_panel_space = $('.wa-panel-right .chat-space');
+
+      if (is_two_panel) {
+        // Two-panel: check which room is open in the right panel
+        const current_room = right_panel_space.attr('data-current-room');
+
+        if (current_room === res.room) {
+          const active_chat_space = chat_room_item[1].chat_space;
+          if (active_chat_space && typeof active_chat_space.receive_message === 'function') {
+            active_chat_space.receive_message(res, get_time(res.creation));
+            mark_message_read(res.room);
+          }
+        } else if (res.sender_user_no !== me.user_email) {
+          chat_room_item[1].set_as_unread();
+        }
+
+        chat_room_item[1].move_to_top();
+        me.move_room_to_top(chat_room_item);
+        me.refresh_current_filter();
+      } else if ($('.chat-list').is(':visible')) {
+        // Floating widget: user is on the chat list screen
         if (res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
         chat_room_item[1].move_to_top();
         me.move_room_to_top(chat_room_item);
-
-        // refresh filter after message update
         me.refresh_current_filter();
-      }
-      else if ($('.chat-space').is(':visible')) {
-        // User is in an active chat room
+      } else if ($('.chat-space').is(':visible')) {
+        // Floating widget: user has a chat space open
         const current_room = $('.chat-space').attr('data-current-room');
 
         if (current_room === res.room) {
-          // Update the active chat space with new message
           const active_chat_space = chat_room_item[1].chat_space;
           if (active_chat_space && typeof active_chat_space.receive_message === 'function') {
-            // Add the message to the active chat
             active_chat_space.receive_message(res, get_time(res.creation));
-
-            // Mark as read since user is actively viewing this room
             mark_message_read(res.room);
           }
+        } else if (res.sender_user_no !== me.user_email) {
+          chat_room_item[1].set_as_unread();
+        }
 
-          // move room to top
-          chat_room_item[1].move_to_top();
-          me.move_room_to_top(chat_room_item);
-        }
-        else {
-          // Different room is open - mark as unread
-          if (res.sender_user_no !== me.user_email) {
-            chat_room_item[1].set_as_unread();
-          }
-          // Move room to top for background rooms too
-          chat_room_item[1].move_to_top();
-          me.move_room_to_top(chat_room_item);
-        }
-      }
-      else {
-        // Handle case when neither chat-list nor chat-space is visible
-        // This could happen if user is in settings or other screens
+        chat_room_item[1].move_to_top();
+        me.move_room_to_top(chat_room_item);
+      } else {
         if (res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }

--- a/whatsapp_chat/public/js/components/chat_room.js
+++ b/whatsapp_chat/public/js/components/chat_room.js
@@ -108,15 +108,10 @@ export default class ChatRoom {
         // Chat space exists, just refresh the messages
         const refreshed = await this.chat_space.refresh_messages();
         if (refreshed) {
-          // Show the existing chat space and re-fire the event so the
-          // linked-doc button updates for this contact.
+          // Show the existing chat space. ChatSpace.render() (called inside
+          // refresh_messages) already triggers whatsapp:space_opened, so no
+          // further trigger is needed here.
           this.chat_space.$chat_space.show();
-          $(document).trigger('whatsapp:space_opened', {
-            room:       this.profile.room,
-            mobile_no:  this.profile.user_email,
-            room_name:  this.profile.room_name,
-            $container: this.chat_space.$chat_space.find('.wa-linked-doc-container'),
-          });
         } else {
           // If refresh failed, create new instance
           this.create_new_chat_space();
@@ -129,6 +124,9 @@ export default class ChatRoom {
         mark_message_read(this.profile.room);
         this.set_as_read();
       }
+
+      // Mobile: parent class drives single-panel layout (hides list, shows chat)
+      $('.wa-page').addClass('wa-chat-open');
     });
   }
 

--- a/whatsapp_chat/public/js/components/chat_room.js
+++ b/whatsapp_chat/public/js/components/chat_room.js
@@ -108,8 +108,15 @@ export default class ChatRoom {
         // Chat space exists, just refresh the messages
         const refreshed = await this.chat_space.refresh_messages();
         if (refreshed) {
-          // Show the existing chat space
+          // Show the existing chat space and re-fire the event so the
+          // linked-doc button updates for this contact.
           this.chat_space.$chat_space.show();
+          $(document).trigger('whatsapp:space_opened', {
+            room:       this.profile.room,
+            mobile_no:  this.profile.user_email,
+            room_name:  this.profile.room_name,
+            $container: this.chat_space.$chat_space.find('.wa-linked-doc-container'),
+          });
         } else {
           // If refresh failed, create new instance
           this.create_new_chat_space();
@@ -131,11 +138,6 @@ export default class ChatRoom {
       chat_list: this.chat_list,
       profile: this.profile,
     });
-    // Notify other app bundles (e.g. leanerp_whatsapp_chat) that a room opened
-    $(document).trigger('whatsapp:space_opened', {
-      room:      this.profile.room,
-      mobile_no: this.profile.user_email,
-      room_name: this.profile.room_name,
-    });
+    // Event is now fired inside ChatSpace.render() after the DOM is ready.
   }
 }

--- a/whatsapp_chat/public/js/components/chat_room.js
+++ b/whatsapp_chat/public/js/components/chat_room.js
@@ -131,5 +131,11 @@ export default class ChatRoom {
       chat_list: this.chat_list,
       profile: this.profile,
     });
+    // Notify other app bundles (e.g. leanerp_whatsapp_chat) that a room opened
+    $(document).trigger('whatsapp:space_opened', {
+      room:      this.profile.room,
+      mobile_no: this.profile.user_email,
+      room_name: this.profile.room_name,
+    });
   }
 }

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -35,44 +35,24 @@ export default class ChatSpace {
       this.profile.room_name
     );
     const header_html = `
-		<div class='chat-header'>
-			${this.profile.is_admin === true
-			? `<span class='chat-back-button' title='${__('Go Back')}' >
-							${frappe.utils.icon('left')}
-						</span>`
-			: ``
-		}
-			${this.avatar_html}
-			<div class='chat-profile-info'>
-				<div class='chat-profile-name'>
-					<a href='#' onclick='navigateToContact()'>    
-						${__(this.profile.room_name)}
-					</a>
-				<div class='online-circle'></div>
-				</div>
-				<div class='chat-profile-status'>${__('Typing...')}</div>
-			</div>
-		</div>
-	`;
-	// Add this function to handle navigation
-	window.navigateToContact = async () => {
-        const me = this;
-
-        // Find Contact by phone number matching room_name
-        const contact = await frappe.db.get_value('Contact', [
-            ["Contact Phone", "phone", "like", `%${me.profile.user_email}`]
-        ], 'name');
-		if (contact && contact.message && contact.message.name) {
-            const url = `/app/contact/${contact.message.name}`;
-            window.open(url, '_blank');
-        } else {
-            // If no contact found, show a message or navigate to contact list with filter
-            frappe.msgprint({
-                title: __('Contact Not Found'),
-                message: __('No contact found with phone number matching ${me.profile.room_name}')
-            });
+      <div class='chat-header'>
+        ${this.profile.is_admin === true
+          ? `<span class='chat-back-button' title='${__('Go Back')}'>
+               ${frappe.utils.icon('left')}
+             </span>`
+          : ''
         }
-	};
+        ${this.avatar_html}
+        <div class='chat-profile-info'>
+          <div class='chat-profile-name'>
+            ${__(this.profile.room_name)}
+            <div class='online-circle'></div>
+          </div>
+          <div class='chat-profile-status'>${__('Typing...')}</div>
+        </div>
+        <div class='wa-linked-doc-container'></div>
+      </div>
+    `;
     this.$chat_space.append(header_html);
   }
 

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -247,6 +247,9 @@ export default class ChatSpace {
     };
 
     $('.chat-back-button').on('click', function () {
+      // Mobile: return to chat list (CSS hides right panel when class removed)
+      $('.wa-page').removeClass('wa-chat-open');
+      // Legacy: re-render chat list (safe no-op in two-panel mode)
       me.chat_list.render_messages();
       me.chat_list.render();
     });

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -436,6 +436,15 @@ export default class ChatSpace {
     // Set data attribute to track current room
     this.$chat_space.attr('data-current-room', this.profile.room);
 
+    // Fire AFTER the space is in the DOM so wa-linked-doc-container is reachable.
+    // Pass the specific element to avoid a global selector race across chat switches.
+    $(document).trigger('whatsapp:space_opened', {
+      room:       this.profile.room,
+      mobile_no:  this.profile.user_email,
+      room_name:  this.profile.room_name,
+      $container: this.$chat_space.find('.wa-linked-doc-container'),
+    });
+
     this.setup_events();
 
     scroll_to_bottom(this.$chat_space_container);

--- a/whatsapp_chat/public/js/whatsapp_chat.bundle.js
+++ b/whatsapp_chat/public/js/whatsapp_chat.bundle.js
@@ -1,160 +1,143 @@
-// frappe.Chat
-// Author - Nihal Mittal <nihal@erpnext.com>
-
 import {
-  ChatBubble,
   ChatList,
-  ChatSpace,
-  ChatWelcome,
   get_settings,
-  scroll_to_bottom,
 } from './components';
+
 frappe.provide('frappe.Chat');
 frappe.provide('frappe.Chat.settings');
 
-/** Spawns a chat widget on any web page */
+// Register as a standard page — frappe.views.pageview.with_page checks this
+// first (before any DB lookup), creates the wrapper synchronously, then data
+// loads async. This is the same pattern used by frappe's Workspaces page.
+frappe.standard_pages['whatsapp'] = function () {
+  const wrapper = frappe.container.add_page('whatsapp');
+
+  frappe.ui.make_app_page({
+    parent: wrapper,
+    title: __('WhatsApp'),
+    single_column: true,
+  });
+
+  frappe.Chat._setup_page_layout(wrapper);
+
+  $(wrapper).bind('show', function () {
+    frappe.Chat._handle_route_params();
+  });
+};
+
 frappe.Chat = class {
   constructor() {
-    this.setup_app();
+    this._setup();
   }
 
-  /** Create all the required elements for chat widget */
-  create_app() {
-    this.$app_element = $(document.createElement('div'));
-    this.$app_element.addClass('chat-app');
-    this.$chat_container = $(document.createElement('div'));
-    this.$chat_container.addClass('chat-container');
-    $('body').append(this.$app_element);
-    this.is_open = false;
-
-    this.$chat_element = $(document.createElement('div'))
-      .addClass('chat-element')
-      .hide();
-
-    this.$chat_element.append(`
-			<span class="chat-cross-button">
-				${frappe.utils.icon('close', 'lg')}
-			</span>
-		`);
-    this.$chat_element.append(this.$chat_container);
-    this.$chat_element.appendTo(this.$app_element);
-
-    this.chat_bubble = new ChatBubble(this);
-    this.chat_bubble.render();
-
-    const navbar_icon_html = `
-        <li class='nav-item dropdown dropdown-notifications 
-          dropdown-mobile chat-navbar-icon' title="Show Chats" >
-          ${frappe.utils.icon('small-message', 'md')}
-          <span class="badge" id="chat-notification-count"></span>
-        </li>
-    `;
-
-    if (this.is_desk === true) {
-      $('header.navbar > .container > .navbar-collapse > ul').prepend(
-        navbar_icon_html
-      );
-    }
-    this.setup_events();
-  }
-
-  /** Load dependencies and fetch the settings */
-  async setup_app() {
+  async _setup() {
     try {
+      if (!('desk' in frappe)) return;
+
       const token = localStorage.getItem('guest_token') || '';
       const res = await get_settings(token);
-      this.is_admin = res.is_admin;
-      this.is_desk = 'desk' in frappe;
 
-      if (res.enable_chat === false || (!this.is_desk && this.is_admin)) {
-        return;
-      }
+      if (res.enable_chat === false || !res.is_admin) return;
 
-      this.create_app();
+      frappe.Chat.settings = frappe.Chat.settings || {};
+      frappe.Chat.settings.user = res.user_settings;
+      frappe.Chat.settings.unread_count = frappe.Chat.settings.unread_count || 0;
+      frappe.Chat._config = res;
+
       await frappe.socketio.init(res.socketio_port);
+      this._inject_navbar_icon();
+    } catch (err) {
+      console.error('WhatsApp Chat init error:', err);
+    }
+  }
 
-      frappe.Chat.settings = {};
+  _inject_navbar_icon() {
+    if ($('.chat-navbar-icon').length) return;
+
+    const html = `
+      <li class='nav-item dropdown dropdown-notifications dropdown-mobile chat-navbar-icon'
+          title="${__('WhatsApp')}">
+        ${frappe.utils.icon('small-message', 'md')}
+        <span class="badge" id="chat-notification-count"></span>
+      </li>
+    `;
+    $('header.navbar > .container > .navbar-collapse > ul').prepend(html);
+
+    $('.chat-navbar-icon').on('click', () => window.open('/app/whatsapp', '_blank'));
+  }
+
+  // ── Page lifecycle ────────────────────────────────────────────────────────
+
+  static _setup_page_layout(wrapper) {
+    const page = wrapper.page;
+    const $main = $(page.main).addClass('wa-main').empty();
+    const $wa_page = $('<div class="wa-page"></div>');
+    const $left   = $('<div class="wa-panel-left"></div>');
+    const $right  = $('<div class="wa-panel-right"></div>');
+
+    $right.html(frappe.Chat._empty_state_html());
+    $wa_page.append($left, $right);
+    $main.append($wa_page);
+
+    frappe.Chat._init_chat_list($left, $right);
+  }
+
+  static async _init_chat_list($left, $right) {
+    if (frappe.Chat._page_ready) return;
+
+    let res = frappe.Chat._config;
+    if (!res) {
+      res = await get_settings('');
+      frappe.Chat._config = res;
+      frappe.Chat.settings = frappe.Chat.settings || {};
       frappe.Chat.settings.user = res.user_settings;
       frappe.Chat.settings.unread_count = 0;
+      await frappe.socketio.init(res.socketio_port);
+    }
 
-      if (res.is_admin) {
-        // If the user is admin, render everthing
-        this.chat_list = new ChatList({
-          $wrapper: this.$chat_container,
-          user: res.user,
-          user_email: res.user_email,
-          is_admin: res.is_admin,
-        });
-        this.chat_list.render();
-      } else if (res.is_verified) {
-        // If the token and ip address matches, directly render the chat space
-        this.chat_space = new ChatSpace({
-          $wrapper: this.$chat_container,
-          profile: {
-            room_name: res.guest_title,
-            room: res.room,
-            is_admin: res.is_admin,
-            user: res.user,
-            user_email: res.user_email,
-          },
-        });
-      } else {
-        //Render the welcome screen if the user is not verified
-        this.chat_welcome = new ChatWelcome({
-          $wrapper: this.$chat_container,
-          profile: {
-            name: res.guest_title,
-            is_admin: res.is_admin,
-            chat_status: res.chat_status,
-          },
-        });
-        this.chat_welcome.render();
-      }
-    } catch (error) {
-      console.error(error);
+    if (!res || !res.is_admin) return;
+
+    frappe.Chat._chat_list = new ChatList({
+      $wrapper:       $left,
+      $space_wrapper: $right,
+      user:           res.user,
+      user_email:     res.user_email,
+      is_admin:       res.is_admin,
+    });
+    frappe.Chat._chat_list.render();
+    frappe.Chat._page_ready = true;
+
+    frappe.Chat._handle_route_params();
+  }
+
+  static _empty_state_html() {
+    return `
+      <div class="wa-empty-state">
+        <div class="wa-empty-icon">${frappe.utils.icon('small-message', 'xl')}</div>
+        <h4>${__('Select a conversation')}</h4>
+        <p class="text-muted">${__('Choose a chat from the left panel to start messaging.')}</p>
+      </div>
+    `;
+  }
+
+  // Auto-open a room when the URL carries a phone number:
+  // frappe.set_route('whatsapp', '918928471344')
+  static _handle_route_params() {
+    const route = frappe.get_route();
+    if (route && route.length > 1) {
+      frappe.Chat._open_room_by_phone(String(route[1]));
     }
   }
 
-  /** Shows the chat widget */
-  show_chat_widget() {
-    this.is_open = true;
-    this.$chat_element.fadeIn(250);
-    if (typeof this.chat_space !== 'undefined') {
-      scroll_to_bottom(this.chat_space.$chat_space_container);
-    }
-  }
+  static _open_room_by_phone(phone) {
+    if (!frappe.Chat._chat_list) return;
+    const last10 = phone.slice(-10);
 
-  /** Hides the chat widget */
-  hide_chat_widget() {
-    this.is_open = false;
-    this.$chat_element.fadeOut(300);
-  }
-
-  should_close(e) {
-    const chat_app = $('.chat-app');
-    const navbar = $('.navbar');
-    const modal = $('.modal');
-    return (
-      !chat_app.is(e.target) &&
-      chat_app.has(e.target).length === 0 &&
-      !navbar.is(e.target) &&
-      navbar.has(e.target).length === 0 &&
-      !modal.is(e.target) &&
-      modal.has(e.target).length === 0
+    const match = frappe.Chat._chat_list.chat_rooms.find(([, room]) =>
+      String(room.profile.user_email || '').slice(-10) === last10
     );
-  }
 
-  setup_events() {
-    const me = this;
-    $('.chat-navbar-icon').on('click', function () {
-      me.chat_bubble.change_bubble();
-    });
-
-    $(document).mouseup(function (e) {
-      if (me.should_close(e) && me.is_open === true) {
-        me.chat_bubble.change_bubble();
-      }
-    });
+    if (match) match[1].$chat_room.trigger('click');
   }
 };
 

--- a/whatsapp_chat/whatsapp_chat/page/whatsapp/whatsapp.json
+++ b/whatsapp_chat/whatsapp_chat/page/whatsapp/whatsapp.json
@@ -1,0 +1,18 @@
+{
+ "content": null,
+ "creation": "2025-05-11 00:00:00.000000",
+ "docstatus": 0,
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2025-05-11 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Whatsapp Chat",
+ "name": "whatsapp",
+ "owner": "Administrator",
+ "page_name": "WhatsApp",
+ "roles": [],
+ "script": null,
+ "standard": "Yes",
+ "style": null,
+ "system_page": 0
+}


### PR DESCRIPTION
## Release Notes
Replaces the floating popup chat widget with a routed full-screen page at /app/whatsapp, styled as a two-panel WhatsApp Web–style layout. Includes bug fixes for page registration, room list filtering, and socket-driven UI updates.

# Changes

## Full-screen page (whatsapp_chat.bundle.js)

Replaced frappe.pages['whatsapp'] pre-registration (which caused a blank page) with frappe.standard_pages['whatsapp'] — the correct Frappe pattern, same as the Workspaces page
Page wrapper and make_app_page are now created synchronously on first route; chat data loads async after
Navbar message icon click opens /app/whatsapp in a new tab instead of showing a popup
on_page_show wired via $(wrapper).bind('show', ...) — auto-opens a contact's chat when URL carries a phone number (e.g. /app/whatsapp/9876543210)

## Two-panel layout

Left panel (320 px fixed): ChatList
Right panel (flex): ChatSpace, defaults to an empty-state placeholder until a conversation is selected
ChatList accepts a $space_wrapper option so rooms render in the right panel without replacing the list

## Bug fixes

chat_list.js: Initialised this.chat_rooms = [] in setup() — prevented a "not iterable" crash when the search box was used before the async room fetch completed
chat_room.js: Added $(document).trigger('whatsapp:space_opened', { room, mobile_no, room_name }) when a chat opens — consumed by downstream apps to inject contextual buttons
contacts.py: Removed the 24-hour activity window filter — the chat list now shows all contacts with any message history, not just those active in the last day
chat_space.js — Removed the broken client-side navigateToContact() function (Contact-only, no Lead/Customer fallback, used frappe.db directly in the browser).


## CSS (whatsapp_chat.bundle.scss)

Added .wa-page, .wa-panel-left, .wa-panel-right, .wa-empty-state, .wa-linked-doc-container, .wa-linked-doc-btn