### PR TITLE
feat(chat): sender/sort filters, sent-by labels, and layout/perf fixes

### DIFF
--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -16,32 +16,67 @@ def get_all(room: str, user_no: str):
     (
         -- Row for text message (only if message exists)
         SELECT
-            creation,
-            CASE WHEN `to` <> '' THEN `to` ELSE 'Administrator' END AS sender_user_no,
-            message AS content
-        FROM `tabWhatsApp Message`
+            m.creation,
+            CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
+            m.message AS content,
+            m.type AS type,
+            COALESCE(u.full_name, m.owner) AS sent_by
+        FROM `tabWhatsApp Message` m
+        LEFT JOIN `tabUser` u ON u.name = m.owner
         WHERE
-            message IS NOT NULL AND message <> ''
-            AND (RIGHT(`to`, 10) = %(user_no)s OR RIGHT(`from`, 10) = %(user_no)s)
+            m.message IS NOT NULL AND m.message <> ''
+            AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
     )
-    
+
     UNION ALL
-    
+
     (
         -- Row for attachment (only if attach exists)
         SELECT
-            creation,
-            CASE WHEN `to` <> '' THEN `to` ELSE 'Administrator' END AS sender_user_no,
-            attach AS content
-        FROM `tabWhatsApp Message`
+            m.creation,
+            CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
+            m.attach AS content,
+            m.type AS type,
+            COALESCE(u.full_name, m.owner) AS sent_by
+        FROM `tabWhatsApp Message` m
+        LEFT JOIN `tabUser` u ON u.name = m.owner
         WHERE
-            attach IS NOT NULL AND attach <> ''
-            AND (RIGHT(`to`, 10) = %(user_no)s OR RIGHT(`from`, 10) = %(user_no)s)
+            m.attach IS NOT NULL AND m.attach <> ''
+            AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
     )
-    
+
     ORDER BY creation ASC
     """,
         {"user_no": user_no[-10:]},
+        as_dict=True,
+    )
+
+
+@frappe.whitelist()
+def get_room_senders(phones=None):
+    """Return distinct (owner, `to`) pairs for outgoing messages to the given phone numbers, so the
+    client can build an owner -> rooms index for the 'Sent by' filter. Scoped to the numbers passed
+    in (the rooms actually shown — contacts with an incoming message in the last 24h), so we don't
+    scan/return senders for rooms that aren't displayed. The client maps each `to` to a loaded room
+    by last-10-digit match (no non-indexable RIGHT()=RIGHT() join).
+
+    Args:
+        phones: JSON list of last-10-digit phone numbers for the displayed rooms.
+    """
+    phones = frappe.parse_json(phones) if phones else []
+    phones = [p for p in phones if p]
+    if not phones:
+        return []
+
+    return frappe.db.sql(
+        """
+        SELECT DISTINCT owner, `to`
+        FROM `tabWhatsApp Message`
+        WHERE type = 'Outgoing'
+          AND `to` <> ''
+          AND RIGHT(`to`, 10) IN %(phones)s
+        """,
+        {"phones": tuple(phones)},
         as_dict=True,
     )
 

--- a/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
+++ b/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
@@ -148,6 +148,13 @@ $height: 582px;
     }
   }
 
+  .chat-list-empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: $font-size-sm;
+  }
+
   .chat-rooms-container {
     height: calc_height($height, 0px);
     overflow-y: scroll;
@@ -277,9 +284,24 @@ $height: 582px;
         max-width: 78%;
       }
     }
+    .message-sender {
+      font-size: $font-size-xs;
+      font-weight: 600;
+      color: var(--text-muted);
+    }
     .message-time {
       font-size: $font-size-xs;
       color: var(--text-muted);
+    }
+    .message-meta {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      .message-time::before {
+        content: "·";
+        margin-right: 6px;
+        color: var(--text-muted);
+      }
     }
     .date-line {
       width: 100%;
@@ -486,13 +508,62 @@ $height: 582px;
 .wa-main {
   padding: 0 !important;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px); // viewport minus Frappe navbar
+}
+
+// Full-width filter header above both panels; keeps the chat list and
+// conversation columns top-aligned and equal height.
+.wa-filters-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px $padding-chat-lr;
+  border-top: 1px solid var(--dark-border-color);
+  border-bottom: 1px solid var(--dark-border-color);
+
+  .wa-filter-sentby {
+    flex: 0 0 240px;
+    min-width: 0;
+  }
+  .wa-filter-sort {
+    flex: 0 0 170px;
+    height: 28px;
+    font-size: $font-size-sm;
+  }
+  .wa-filter-sentby .frappe-control,
+  .wa-filter-sentby .control-input-wrapper,
+  .wa-filter-sentby .control-input,
+  .wa-filter-sentby input {
+    margin: 0;
+    width: 100%;
+  }
+  .wa-filter-sentby input {
+    height: 28px;
+  }
+  .unread-filter-container {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin: 0;
+    cursor: pointer;
+    white-space: nowrap;
+    font-size: $font-size-sm;
+    color: var(--text-color);
+  }
+  .unread-filter-checkbox {
+    margin: 0;
+  }
 }
 
 .wa-page {
   display: flex;
-  height: calc(100vh - 60px); // viewport minus Frappe navbar
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: hidden;
-  border-top: 1px solid var(--dark-border-color);
 }
 
 .wa-panel-left {
@@ -581,23 +652,26 @@ $height: 582px;
   .wa-linked-doc-btn {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    font-size: $font-size-xs;
-    color: var(--primary-color);
-    border: 1px solid var(--primary-color);
-    border-radius: 4px;
-    padding: 3px 8px;
+    gap: 6px;
+    font-size: $font-size-sm;
+    font-weight: 500;
+    color: var(--blue-600, #2490ef);
+    background: var(--bg-blue, #f0f6ff);
+    border: none;
+    border-radius: var(--border-radius-full, 20px);
+    padding: 4px 12px;
     white-space: nowrap;
     text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease;
 
     svg {
       flex-shrink: 0;
+      fill: currentColor;
     }
 
     &:hover {
-      background: var(--primary-color);
-      color: var(--white);
-      svg { fill: var(--white); }
+      background: var(--blue-100, #d6e9fb);
+      color: var(--blue-700, #1366b3);
       text-decoration: none;
     }
   }

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -1,7 +1,7 @@
 import ChatRoom from './chat_room';
 import ChatAddRoom from './chat_add_room';
 import ChatUserSettings from './chat_user_settings';
-import { get_rooms, mark_message_read, get_time } from './chat_utils';
+import { get_rooms, mark_message_read, get_time, get_room_senders } from './chat_utils';
 
 export default class ChatList {
   constructor(opts) {
@@ -9,9 +9,12 @@ export default class ChatList {
     // In two-panel (full-screen) mode the caller passes a separate wrapper
     // for ChatSpace so the left panel is never replaced by a chat view.
     this.$space_wrapper = opts.$space_wrapper || opts.$wrapper;
+    this.$filters_wrapper = opts.$filters_wrapper;
     this.user = opts.user;
     this.user_email = opts.user_email;
     this.is_admin = opts.is_admin;
+    this.sender_room_set = null;
+    this.sort_by = 'latest';
     this.setup();
   }
 
@@ -19,6 +22,7 @@ export default class ChatList {
     this.$chat_list = $(document.createElement('div'));
     this.$chat_list.addClass('chat-list');
     this.chat_rooms = [];
+    this.setup_filters();
     this.setup_header();
     this.setup_search();
     this.fetch_and_setup_rooms();
@@ -30,10 +34,6 @@ export default class ChatList {
     <div class='chat-list-header'>
       <div class='header-left'>
         <h3>${__('Chats')}</h3>
-        <label class='unread-filter-container'>
-          <input type='checkbox' class='unread-filter-checkbox'>
-          <span class='checkmark'>${__('Unread')}</span>
-        </label>
       </div>
       <div class='chat-list-icons'>
         <div class='add-room' title='Create Private Room'>
@@ -65,12 +65,30 @@ export default class ChatList {
     this.$chat_list.append(chat_list_search_html);
   }
 
+  setup_filters() {
+    // Rendered into the full-width filter bar above both panels (see render()).
+    this.filters_html = `
+      <div class='wa-filter-sentby' title='${__('Filter by sender')}'></div>
+      <select class='form-control wa-filter-sort' title='${__('Sort by')}'>
+        <option value='latest'>${__('Latest message first')}</option>
+        <option value='oldest'>${__('Oldest first')}</option>
+        <option value='name'>${__('Name A–Z')}</option>
+        <option value='unread'>${__('Unread first')}</option>
+      </select>
+      <label class='unread-filter-container' title='${__('Show unread only')}'>
+        <input type='checkbox' class='unread-filter-checkbox'>
+        <span class='checkmark'>${__('Unread')}</span>
+      </label>
+    `;
+  }
+
   async fetch_and_setup_rooms() {
     try {
       const res = await get_rooms(this.user_email);
       this.rooms = res;
       this.setup_rooms();
       this.render_messages();
+      this.refresh_current_filter();
     } catch (error) {
       frappe.msgprint({
         title: __('Error'),
@@ -78,11 +96,42 @@ export default class ChatList {
       });
       console.error(error);
     }
+
+    // Load the "Sent by" index independently — it must never block or break
+    // the room list. If it fails, the filter simply matches nothing until reload.
+    this.load_sender_index();
+  }
+
+  async load_sender_index() {
+    try {
+      // Map last-10 phone digits -> room name from the already-loaded rooms,
+      // so we can resolve message `to` numbers to rooms on the client.
+      const phone_to_room = {};
+      for (const [room_name, room] of this.chat_rooms) {
+        const phone = String(room.profile.user_email || '').slice(-10);
+        if (phone) phone_to_room[phone] = room_name;
+      }
+
+      // Only ask the backend for senders of the rooms we actually show.
+      const pairs = await get_room_senders(Object.keys(phone_to_room));
+
+      this.sender_index = {};
+      for (const { owner, to } of pairs || []) {
+        const room = phone_to_room[String(to).slice(-10)];
+        if (!room) continue;
+        (this.sender_index[owner] =
+          this.sender_index[owner] || new Set()).add(room);
+      }
+    } catch (error) {
+      this.sender_index = {};
+      console.error(error);
+    }
   }
 
   setup_rooms() {
     this.$chat_rooms_container = $(document.createElement('div'));
     this.$chat_rooms_container.addClass('chat-rooms-container');
+    this.$empty_placeholder = $('<div class="chat-list-empty"></div>').hide();
     this.chat_rooms = [];
     //console.log(this.rooms)
     this.rooms.forEach((element) => {
@@ -114,6 +163,7 @@ export default class ChatList {
   }
 
   filter_rooms(query, showOnlyUnread = false) {
+    let visibleCount = 0;
     for (const room of this.chat_rooms) {
       const txt = room[1].profile.room_name.toLowerCase();
       const matchesSearch = query === '' || txt.includes(query);
@@ -125,12 +175,69 @@ export default class ChatList {
           room[1].profile.message_type === 'Incoming';
       }
 
-      if (matchesSearch && matchesFilter) {
+      // Only chats with at least one outgoing message from the selected user
+      const matchesSender =
+        !this.sender_room_set || this.sender_room_set.has(room[0]);
+
+      if (matchesSearch && matchesFilter && matchesSender) {
         room[1].$chat_room.show();
+        visibleCount += 1;
       } else {
         room[1].$chat_room.hide();
       }
     }
+
+    if (this.$empty_placeholder) {
+      if (visibleCount === 0) {
+        const filter_active =
+          query !== '' || showOnlyUnread || !!this.sender_room_set;
+        const msg = filter_active
+          ? __('No chats match this filter')
+          : __('No conversations yet');
+        this.$empty_placeholder.text(msg);
+        this.$chat_rooms_container.append(this.$empty_placeholder);
+        this.$empty_placeholder.show();
+      } else {
+        this.$empty_placeholder.hide();
+      }
+    }
+  }
+
+  on_sender_change() {
+    const owner = this.sentby_control ? this.sentby_control.get_value() : '';
+    this.sender_room_set = owner
+      ? (this.sender_index && this.sender_index[owner]) || new Set()
+      : null;
+    this.refresh_current_filter();
+  }
+
+  sort_rooms() {
+    const last_date = (r) => new Date(r[1].profile.last_date || 0).getTime();
+    const is_unread = (r) =>
+      r[1].profile.is_read === 0 &&
+      r[1].profile.message_type === 'Incoming';
+
+    this.chat_rooms.sort((a, b) => {
+      switch (this.sort_by) {
+        case 'oldest':
+          return last_date(a) - last_date(b);
+        case 'name':
+          return (a[1].profile.room_name || '').localeCompare(
+            b[1].profile.room_name || ''
+          );
+        case 'unread':
+          if (is_unread(a) !== is_unread(b)) {
+            return is_unread(a) ? -1 : 1;
+          }
+          return last_date(b) - last_date(a);
+        case 'latest':
+        default:
+          return last_date(b) - last_date(a);
+      }
+    });
+
+    this.render_messages();
+    this.refresh_current_filter();
   }
 
   create_new_room(profile) {
@@ -162,6 +269,12 @@ export default class ChatList {
       me.filter_rooms(query, showOnlyUnread);
     });
 
+    // Handle sort dropdown
+    $('.wa-filter-sort').on('change', function () {
+      me.sort_by = $(this).val();
+      me.sort_rooms();
+    });
+
     $('.add-room').on('click', function (e) {
       if (typeof me.chat_add_room_modal === 'undefined') {
         me.chat_add_room_modal = new ChatAddRoom({
@@ -189,7 +302,31 @@ export default class ChatList {
 
   render() {
     this.$wrapper.html(this.$chat_list);
+    if (this.$filters_wrapper) {
+      this.$filters_wrapper.html(this.filters_html);
+    }
+    this.setup_sentby_control();
     this.setup_events();
+  }
+
+  setup_sentby_control() {
+    const me = this;
+    const $parent = this.$filters_wrapper
+      ? this.$filters_wrapper.find('.wa-filter-sentby')
+      : $();
+    if (!$parent.length || this.sentby_control) return;
+
+    this.sentby_control = frappe.ui.form.make_control({
+      df: {
+        fieldtype: 'Link',
+        options: 'User',
+        placeholder: __('Sent by'),
+        onchange: () => me.on_sender_change(),
+      },
+      parent: $parent.get(0),
+      render_input: true,
+    });
+    this.sentby_control.refresh();
   }
 
   move_room_to_top(chat_room_item) {

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -126,6 +126,13 @@ export default class ChatList {
       this.sender_index = {};
       console.error(error);
     }
+
+    // If the user picked a sender before the index finished loading,
+    // on_sender_change() stored an empty Set — re-apply it now that the
+    // index is ready so the list reflects the active selection.
+    if (this.sentby_control && this.sentby_control.get_value()) {
+      this.on_sender_change();
+    }
   }
 
   setup_rooms() {
@@ -250,7 +257,12 @@ export default class ChatList {
         element: profile,
       }),
     ]);
-    this.chat_rooms[0][1].render('prepend');
+    if (this.sort_by === 'latest') {
+      this.chat_rooms[0][1].render('prepend');
+    } else {
+      // Respect the active sort for newly created rooms too.
+      this.sort_rooms();
+    }
   }
 
   setup_events() {
@@ -336,6 +348,18 @@ export default class ChatList {
     ];
   }
 
+  // Reorder the list after a realtime update. Moving to the top is only correct
+  // for the default "latest" sort; for any other sort, re-run sort_rooms() so a
+  // live update doesn't break the user's chosen order (name / oldest / unread).
+  reorder_room(chat_room_item) {
+    if (this.sort_by === 'latest') {
+      chat_room_item[1].move_to_top();
+      this.move_room_to_top(chat_room_item);
+    } else {
+      this.sort_rooms();
+    }
+  }
+
   setup_socketio() {
     const me = this;
     frappe.realtime.on('latest_chat_updates', function (res) {
@@ -375,16 +399,14 @@ export default class ChatList {
           chat_room_item[1].set_as_unread();
         }
 
-        chat_room_item[1].move_to_top();
-        me.move_room_to_top(chat_room_item);
+        me.reorder_room(chat_room_item);
         me.refresh_current_filter();
       } else if ($('.chat-list').is(':visible')) {
         // Floating widget: user is on the chat list screen
         if (res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
-        chat_room_item[1].move_to_top();
-        me.move_room_to_top(chat_room_item);
+        me.reorder_room(chat_room_item);
         me.refresh_current_filter();
       } else if ($('.chat-space').is(':visible')) {
         // Floating widget: user has a chat space open
@@ -400,14 +422,12 @@ export default class ChatList {
           chat_room_item[1].set_as_unread();
         }
 
-        chat_room_item[1].move_to_top();
-        me.move_room_to_top(chat_room_item);
+        me.reorder_room(chat_room_item);
       } else {
         if (res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
-        chat_room_item[1].move_to_top();
-        me.move_room_to_top(chat_room_item);
+        me.reorder_room(chat_room_item);
       }
     });
 

--- a/whatsapp_chat/public/js/components/chat_room.js
+++ b/whatsapp_chat/public/js/components/chat_room.js
@@ -74,6 +74,9 @@ export default class ChatRoom {
   }
 
   set_last_message(message, date) {
+    // Keep last_date current so time-based sorts (latest/oldest) re-sort correctly
+    // when sort_rooms() runs after a realtime update.
+    this.profile.last_date = date;
     const sanitized_message = this.sanitize_last_message(message);
     this.$chat_room.find('.last-message').html(__(sanitized_message));
     this.$chat_room.find('.chat-date').text(__(get_time(date)));
@@ -103,7 +106,9 @@ export default class ChatRoom {
   }
 
   setup_events() {
-    this.$chat_room.on('click', async () => {
+    // off() first so repeated re-renders (e.g. sort_rooms on realtime updates)
+    // don't stack duplicate click handlers on the same element.
+    this.$chat_room.off('click').on('click', async () => {
       if (typeof this.chat_space !== 'undefined') {
         // Chat space exists, just refresh the messages
         const refreshed = await this.chat_space.refresh_messages();

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -100,20 +100,28 @@ export default class ChatSpace {
       const date_line_html = this.make_date_line_html(element.creation);
       this.message_html += date_line_html;
 
-      let message_type = 'sender';
-
-      if (element.sender_user_no === this.profile.user_email) {
+      let message_type;
+      if (element.type === 'Outgoing') {
         message_type = 'recipient';
-      } else if (this.profile.room_type === 'Guest') {
-        if (this.profile.is_admin === true && element.sender !== 'Guest') {
+      } else if (element.type === 'Incoming') {
+        message_type = 'sender';
+      } else {
+        // Fallback: legacy/guest rows without an explicit type
+        message_type = 'sender';
+        if (element.sender_user_no === this.profile.user_email) {
           message_type = 'recipient';
+        } else if (this.profile.room_type === 'Guest') {
+          if (this.profile.is_admin === true && element.sender !== 'Guest') {
+            message_type = 'recipient';
+          }
         }
       }
       this.message_html += this.make_message(
         element.content,
         get_time(element.creation),
         message_type,
-        element.sender
+        element.sender,
+        element.sent_by
       ).prop('outerHTML');
 
       this.prevMessage = element;
@@ -310,7 +318,7 @@ export default class ChatSpace {
     }
   }
 
-  make_message(content, time, type, name) {
+  make_message(content, time, type, name, sent_by) {
     const message_class =
       type === 'recipient' ? 'recipient-message' : 'sender-message';
     const $recipient_element = $(document.createElement('div')).addClass(
@@ -356,7 +364,20 @@ export default class ChatSpace {
     }
     $message_element.append($sanitized_content);
     $recipient_element.append($message_element);
-    $recipient_element.append(`<div class='message-time'>${__(time)}</div>`);
+
+    if (type === 'recipient' && sent_by) {
+      $recipient_element.append(
+        $('<div class="message-meta"></div>')
+          .append(
+            $('<span class="message-sender"></span>').text(
+              __('Sent by {0}', [sent_by])
+            )
+          )
+          .append($('<span class="message-time"></span>').text(__(time)))
+      );
+    } else {
+      $recipient_element.append(`<div class='message-time'>${__(time)}</div>`);
+    }
 
     return $recipient_element;
   }
@@ -387,7 +408,13 @@ export default class ChatSpace {
     }
 
     this.$chat_space_container.append(
-      this.make_message(content, get_time(), 'recipient', this.profile.user)
+      this.make_message(
+        content,
+        get_time(),
+        'recipient',
+        this.profile.user,
+        frappe.user.full_name()
+      )
     );
     $type_message.val('');
     scroll_to_bottom(this.$chat_space_container);

--- a/whatsapp_chat/public/js/components/chat_utils.js
+++ b/whatsapp_chat/public/js/components/chat_utils.js
@@ -67,6 +67,16 @@ async function get_messages(room, user_no) {
   return await res.message;
 }
 
+async function get_room_senders(phones) {
+  const res = await frappe.call({
+    method: 'whatsapp_chat.api.message.get_room_senders',
+    args: {
+      phones: JSON.stringify(phones || []),
+    },
+  });
+  return (await res.message) || [];
+}
+
 async function send_message(content, user, room, user_no, attachment) {
   try {
     await frappe.call({
@@ -191,6 +201,7 @@ export {
   scroll_to_bottom,
   get_rooms,
   get_messages,
+  get_room_senders,
   get_settings,
   create_guest,
   send_message,

--- a/whatsapp_chat/public/js/whatsapp_chat.bundle.js
+++ b/whatsapp_chat/public/js/whatsapp_chat.bundle.js
@@ -21,8 +21,11 @@ frappe.standard_pages['whatsapp'] = function () {
   frappe.Chat._setup_page_layout(wrapper);
 
   $(wrapper).bind('show', function () {
+    frappe.Chat._fit_height();
     frappe.Chat._handle_route_params();
   });
+
+  $(window).off('resize.wa_chat').on('resize.wa_chat', () => frappe.Chat._fit_height());
 };
 
 frappe.Chat = class {
@@ -71,18 +74,32 @@ frappe.Chat = class {
   static _setup_page_layout(wrapper) {
     const page = wrapper.page;
     const $main = $(page.main).addClass('wa-main').empty();
+    const $filter_bar = $('<div class="wa-filters-bar"></div>');
     const $wa_page = $('<div class="wa-page"></div>');
     const $left   = $('<div class="wa-panel-left"></div>');
     const $right  = $('<div class="wa-panel-right"></div>');
 
     $right.html(frappe.Chat._empty_state_html());
     $wa_page.append($left, $right);
-    $main.append($wa_page);
+    $main.append($filter_bar, $wa_page);
 
-    frappe.Chat._init_chat_list($left, $right);
+    frappe.Chat._fit_height();
+    frappe.Chat._init_chat_list($left, $right, $filter_bar);
   }
 
-  static async _init_chat_list($left, $right) {
+  // Size the chat area to exactly fill from its top to the viewport bottom, so
+  // the message input is always visible (no page scrollbar). Measured at runtime
+  // because the page-head/navbar heights vary by theme.
+  static _fit_height() {
+    const $main = $('.wa-main');
+    if (!$main.length) return;
+    const top = $main[0].getBoundingClientRect().top;
+    if (top > 0) {
+      $main.css('height', `calc(100vh - ${Math.round(top)}px)`);
+    }
+  }
+
+  static async _init_chat_list($left, $right, $filter_bar) {
     if (frappe.Chat._page_ready) return;
 
     let res = frappe.Chat._config;
@@ -98,11 +115,12 @@ frappe.Chat = class {
     if (!res || !res.is_admin) return;
 
     frappe.Chat._chat_list = new ChatList({
-      $wrapper:       $left,
-      $space_wrapper: $right,
-      user:           res.user,
-      user_email:     res.user_email,
-      is_admin:       res.is_admin,
+      $wrapper:         $left,
+      $space_wrapper:   $right,
+      $filters_wrapper: $filter_bar,
+      user:             res.user,
+      user_email:       res.user_email,
+      is_admin:         res.is_admin,
     });
     frappe.Chat._chat_list.render();
     frappe.Chat._page_ready = true;


### PR DESCRIPTION
- Add a filter header (above both panels) with a "Sent by" User filter, a "Sort by" dropdown (latest/oldest/name/unread) and an Unread toggle
- Show "Sent by <user> · <time>" on a single line for outgoing messages
- Classify message direction by WhatsApp Message `type` (fixes outgoing messages rendering on the incoming side due to phone-format mismatch)
- Resolve the "Sent by" filter client-side via get_room_senders, scoped to the currently displayed rooms (single-table query, no expensive join)
- Show a "No chats match this filter" placeholder when the list is empty
- Fit the chat area height to the viewport so the input stays visible