### PR TITLE
feat(chat): make chat-list incoming-message window configurable

### DIFF
--- a/whatsapp_chat/api/contacts.py
+++ b/whatsapp_chat/api/contacts.py
@@ -1,5 +1,20 @@
 import frappe
-from frappe.utils import add_to_date, now_datetime
+from frappe.utils import add_to_date, cint, now_datetime
+
+
+def _get_chat_window_days(default_days: int = 7) -> int:
+    """Window (in days) for the chat-list 'recent incoming message' filter.
+
+    Sourced from the Leanerp WhatsApp Settings single. Falls back to the default
+    when the value/doctype is unset or non-positive so the filter stays active.
+    """
+    try:
+        days = cint(
+            frappe.db.get_single_value("Leanerp WhatsApp Settings", "chat_list_window_days")
+        )
+    except Exception:
+        return default_days
+    return days if days > 0 else default_days
 
 
 @frappe.whitelist()
@@ -23,8 +38,8 @@ def get(email):
         "WhatsApp Contact", fields=["*"], order_by="modified desc"
     )
 
-    # Get datetime for 1 day ago
-    one_day_ago = add_to_date(now_datetime(), days=-1)
+    # Only include contacts with an incoming message within the configured window.
+    window_start = add_to_date(now_datetime(), days=-_get_chat_window_days())
 
     mobile_nos = frappe.db.sql(
         """
@@ -33,12 +48,12 @@ def get(email):
         WHERE `from` IS NOT NULL
             AND TRIM(`from`) != ''
             AND LENGTH(TRIM(`from`)) >= 10
-            AND creation >= %(one_day_ago)s
+            AND creation >= %(window_start)s
         HAVING mobile_no IS NOT NULL
             AND mobile_no != ''
         ORDER BY mobile_no;
     """,
-        {"one_day_ago": one_day_ago},
+        {"window_start": window_start},
         as_list=True,
     )
 


### PR DESCRIPTION
The WhatsApp chat list showed a contact only if it had an incoming message in the last 24 hours (hardcoded). Source the window from the new "Chat List Window (Days)" setting on Leanerp WhatsApp Settings, defaulting to 7 days and falling back to 7 when unset or 0 so the filter stays active.