### PR TITLE
Feat: Chat UX: phone search, AI-chats filter hook, lazy loading, live auto-update, reply permissions

### DIFF
--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -4,7 +4,7 @@ import frappe
 
 # Roles that may reply to any chat. Everyone can *view* every chat; replying is
 # restricted to managers, the chat's owner, or unassigned (shared-pool) chats.
-MANAGER_ROLES = {"System Manager", "Sales Manager", "WhatsApp Agent"}
+MANAGER_ROLES = {"System Manager", "Sales Manager", "Sales Co-ordinator"}
 
 
 def can_reply_to_contact(contact_email):
@@ -35,28 +35,46 @@ def assert_can_reply_number(to):
 
 
 @frappe.whitelist()
-def get_all(room: str, user_no: str, limit=30, before=None):
+def get_all(room: str, user_no: str, limit=30, before=None, before_name=None, before_kind=None):
     """Get a page of a room's messages for lazy/infinite scroll.
 
     Returns the newest `limit` rows (text + attachment), in ascending order for
-    display. Pass `before` (a creation timestamp) to fetch the next older page.
+    display. For the next older page pass the oldest row's composite cursor —
+    `before` (its `creation`), `before_name` (its message `name`) and
+    `before_kind` (0=text, 1=attachment). The UNION can emit two rows per message
+    with the same creation, so the (creation, name, kind) cursor is required to
+    avoid skipping/duplicating rows at page boundaries.
 
     Args:
         room (str): Room's name.
         user_no (str): Counterpart phone number.
-        limit (int): Page size.
-        before (str|None): Only rows older than this creation timestamp.
+        limit (int): Page size (clamped to 1..200).
+        before / before_name / before_kind: composite "older than" cursor.
     """
-    limit = int(limit)
+    # limit is user-controlled (whitelisted) — parse defensively and clamp.
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 30
+    limit = max(1, min(limit, 200))
+
     # frappe.call() JSON-encodes args, so a JS `null` arrives as the string "null".
     if before in (None, "", "null", "undefined"):
         before = None
+    if before_name in (None, "", "null", "undefined"):
+        before_name = None
+    try:
+        before_kind = int(before_kind)
+    except (TypeError, ValueError):
+        before_kind = 0
+
     rows = frappe.db.sql(
         """
         SELECT * FROM (
             (
                 -- Row for text message (only if message exists)
                 SELECT
+                    m.name AS name, 0 AS kind,
                     m.creation,
                     CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
                     m.message AS content,
@@ -72,6 +90,7 @@ def get_all(room: str, user_no: str, limit=30, before=None):
             (
                 -- Row for attachment (only if attach exists)
                 SELECT
+                    m.name AS name, 1 AS kind,
                     m.creation,
                     CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
                     m.attach AS content,
@@ -84,11 +103,22 @@ def get_all(room: str, user_no: str, limit=30, before=None):
                     AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
             )
         ) AS u
-        WHERE (%(before)s IS NULL OR u.creation < %(before)s)
-        ORDER BY u.creation DESC
+        WHERE (
+            %(before)s IS NULL
+            OR u.creation < %(before)s
+            OR (u.creation = %(before)s AND u.name < %(before_name)s)
+            OR (u.creation = %(before)s AND u.name = %(before_name)s AND u.kind < %(before_kind)s)
+        )
+        ORDER BY u.creation DESC, u.name DESC, u.kind DESC
         LIMIT %(limit)s
         """,
-        {"user_no": user_no[-10:], "before": before, "limit": limit},
+        {
+            "user_no": user_no[-10:],
+            "before": before,
+            "before_name": before_name or "",
+            "before_kind": before_kind,
+            "limit": limit,
+        },
         as_dict=True,
     )
     rows.reverse()  # ascending for display
@@ -274,17 +304,24 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
 
     # Push every message (incoming AND outgoing) so the open chat reflects
     # AI/other-agent/template replies live and the list preview/order updates.
+    payload = {
+        "content": message,
+        "creation": frappe.utils.now(),
+        "room": chat_doc.name,
+        "type": message_type,
+        "owner": owner,
+        "message_id": message_id,
+        "sender_user_no": None if is_outgoing else mobile_no,
+    }
+
+    # Per-room channel: any open ChatSpace (including managers viewing another
+    # agent's chat) subscribes to `this.profile.room` and appends live.
+    frappe.publish_realtime(chat_doc.name, payload)
+
+    # List channel: updates the owner's chat-list preview / order / unread badge.
     if chat_doc.email:
         frappe.publish_realtime(
             "latest_chat_updates",
-            {
-                "content": message,
-                "creation": frappe.utils.now(),
-                "room": chat_doc.name,
-                "type": message_type,
-                "owner": owner,
-                "message_id": message_id,
-                "sender_user_no": None if is_outgoing else mobile_no,
-            },
+            payload,
             user=chat_doc.email,
         )

--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -2,54 +2,97 @@ import mimetypes
 
 import frappe
 
+# Roles that may reply to any chat. Everyone can *view* every chat; replying is
+# restricted to managers, the chat's owner, or unassigned (shared-pool) chats.
+MANAGER_ROLES = {"System Manager", "Sales Manager", "WhatsApp Agent"}
+
+
+def can_reply_to_contact(contact_email):
+    """Whether the current user may reply to a chat owned by `contact_email`."""
+    if MANAGER_ROLES & set(frappe.get_roles(frappe.session.user)):
+        return True
+    # Unassigned (shared pool) or owned by the current user.
+    return not contact_email or contact_email == frappe.session.user
+
+
+def _contact_email_by_number(to):
+    if not to:
+        return None
+    return frappe.db.get_value(
+        "WhatsApp Contact",
+        {"mobile_no": ["like", f"%{to[-10:]}"]},
+        "email",
+        order_by="modified desc",
+    )
+
+
+def assert_can_reply_number(to):
+    if not can_reply_to_contact(_contact_email_by_number(to)):
+        frappe.throw(
+            frappe._("This chat is assigned to another agent — view only."),
+            frappe.PermissionError,
+        )
+
 
 @frappe.whitelist()
-def get_all(room: str, user_no: str):
-    """Get all the messages of a particular room
+def get_all(room: str, user_no: str, limit=30, before=None):
+    """Get a page of a room's messages for lazy/infinite scroll.
+
+    Returns the newest `limit` rows (text + attachment), in ascending order for
+    display. Pass `before` (a creation timestamp) to fetch the next older page.
 
     Args:
         room (str): Room's name.
-
+        user_no (str): Counterpart phone number.
+        limit (int): Page size.
+        before (str|None): Only rows older than this creation timestamp.
     """
-    return frappe.db.sql(
+    limit = int(limit)
+    # frappe.call() JSON-encodes args, so a JS `null` arrives as the string "null".
+    if before in (None, "", "null", "undefined"):
+        before = None
+    rows = frappe.db.sql(
         """
-    (
-        -- Row for text message (only if message exists)
-        SELECT
-            m.creation,
-            CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
-            m.message AS content,
-            m.type AS type,
-            COALESCE(u.full_name, m.owner) AS sent_by
-        FROM `tabWhatsApp Message` m
-        LEFT JOIN `tabUser` u ON u.name = m.owner
-        WHERE
-            m.message IS NOT NULL AND m.message <> ''
-            AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
-    )
-
-    UNION ALL
-
-    (
-        -- Row for attachment (only if attach exists)
-        SELECT
-            m.creation,
-            CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
-            m.attach AS content,
-            m.type AS type,
-            COALESCE(u.full_name, m.owner) AS sent_by
-        FROM `tabWhatsApp Message` m
-        LEFT JOIN `tabUser` u ON u.name = m.owner
-        WHERE
-            m.attach IS NOT NULL AND m.attach <> ''
-            AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
-    )
-
-    ORDER BY creation ASC
-    """,
-        {"user_no": user_no[-10:]},
+        SELECT * FROM (
+            (
+                -- Row for text message (only if message exists)
+                SELECT
+                    m.creation,
+                    CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
+                    m.message AS content,
+                    m.type AS type,
+                    COALESCE(u.full_name, m.owner) AS sent_by
+                FROM `tabWhatsApp Message` m
+                LEFT JOIN `tabUser` u ON u.name = m.owner
+                WHERE
+                    m.message IS NOT NULL AND m.message <> ''
+                    AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
+            )
+            UNION ALL
+            (
+                -- Row for attachment (only if attach exists)
+                SELECT
+                    m.creation,
+                    CASE WHEN m.`to` <> '' THEN m.`to` ELSE 'Administrator' END AS sender_user_no,
+                    m.attach AS content,
+                    m.type AS type,
+                    COALESCE(u.full_name, m.owner) AS sent_by
+                FROM `tabWhatsApp Message` m
+                LEFT JOIN `tabUser` u ON u.name = m.owner
+                WHERE
+                    m.attach IS NOT NULL AND m.attach <> ''
+                    AND (RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)
+            )
+        ) AS u
+        WHERE (%(before)s IS NULL OR u.creation < %(before)s)
+        ORDER BY u.creation DESC
+        LIMIT %(limit)s
+        """,
+        {"user_no": user_no[-10:], "before": before, "limit": limit},
         as_dict=True,
     )
+    rows.reverse()  # ascending for display
+    return rows
 
 
 @frappe.whitelist()
@@ -84,6 +127,10 @@ def get_room_senders(phones=None):
 @frappe.whitelist()
 def mark_as_read(room):
     doc = frappe.get_doc("WhatsApp Contact", room)
+    # A read-only viewer (non-owner, non-manager) opening someone else's chat
+    # must not clear the owner's unread state — skip silently.
+    if not can_reply_to_contact(doc.email):
+        return "skipped"
     doc.is_read = 1
     doc.db_update()
 
@@ -103,6 +150,7 @@ def mark_as_read(room):
 
 @frappe.whitelist()
 def send(content, user, room, user_no, attachment=None):
+    assert_can_reply_number(user_no)
     content_type = "text"
     if attachment:
         file_type = mimetypes.guess_type(content)[0]
@@ -187,10 +235,12 @@ def last_message(doc, method):
         message_type=doc.type,
         profile_name=doc.get("profile_name"),
         is_outgoing=doc.type == "Outgoing",
+        owner=doc.owner,
+        message_id=doc.name,
     )
 
 
-def update_contact_on_message(mobile_no, message, message_type, profile_name, is_outgoing):
+def update_contact_on_message(mobile_no, message, message_type, profile_name, is_outgoing, owner=None, message_id=None):
     contact_name = frappe.db.get_value(
         "WhatsApp Contact",
         filters={"mobile_no": ["like", f"%{mobile_no}"]},  
@@ -222,13 +272,19 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
         )
         chat_doc.insert(ignore_permissions=True)
 
-    if chat_doc.email and not is_outgoing:
+    # Push every message (incoming AND outgoing) so the open chat reflects
+    # AI/other-agent/template replies live and the list preview/order updates.
+    if chat_doc.email:
         frappe.publish_realtime(
             "latest_chat_updates",
             {
                 "content": message,
                 "creation": frappe.utils.now(),
                 "room": chat_doc.name,
+                "type": message_type,
+                "owner": owner,
+                "message_id": message_id,
+                "sender_user_no": None if is_outgoing else mobile_no,
             },
             user=chat_doc.email,
         )

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -79,6 +79,10 @@ export default class ChatList {
         <input type='checkbox' class='unread-filter-checkbox'>
         <span class='checkmark'>${__('Unread')}</span>
       </label>
+      <label class='unread-filter-container' title='${__('Show chats the AI agent has replied to')}'>
+        <input type='checkbox' class='ai-filter-checkbox'>
+        <span class='checkmark'>${__('AI chats')}</span>
+      </label>
     `;
   }
 
@@ -153,7 +157,8 @@ export default class ChatList {
         room_name: element.contact_name,
         room_type: element.type,
         opposite_person_email: element.mobile_no,
-        message_type: element.message_type
+        message_type: element.message_type,
+        ai_replied: element.ai_replied
       };
 
       this.chat_rooms.push([
@@ -169,17 +174,26 @@ export default class ChatList {
     this.$chat_list.append(this.$chat_rooms_container);
   }
 
-  filter_rooms(query, showOnlyUnread = false) {
+  filter_rooms(query, showOnlyUnread = false, showAiOnly = false) {
     let visibleCount = 0;
+    const qDigits = (query || '').replace(/\D/g, '');
     for (const room of this.chat_rooms) {
-      const txt = room[1].profile.room_name.toLowerCase();
-      const matchesSearch = query === '' || txt.includes(query);
+      const name_txt = (room[1].profile.room_name || '').toLowerCase();
+      const phone = String(room[1].profile.opposite_person_email || '').replace(/\D/g, '');
+      // Match on contact name OR phone number digits.
+      const matchesSearch = query === '' ||
+        name_txt.includes(query) ||
+        (qDigits && phone.includes(qDigits));
 
       let matchesFilter = true;
       if (showOnlyUnread) {
         // Show only unread incoming messages
         matchesFilter = room[1].profile.is_read === 0 &&
           room[1].profile.message_type === 'Incoming';
+      }
+      // Show only chats the AI agent has replied to
+      if (matchesFilter && showAiOnly) {
+        matchesFilter = room[1].profile.ai_replied === 1;
       }
 
       // Only chats with at least one outgoing message from the selected user
@@ -197,7 +211,7 @@ export default class ChatList {
     if (this.$empty_placeholder) {
       if (visibleCount === 0) {
         const filter_active =
-          query !== '' || showOnlyUnread || !!this.sender_room_set;
+          query !== '' || showOnlyUnread || showAiOnly || !!this.sender_room_set;
         const msg = filter_active
           ? __('No chats match this filter')
           : __('No conversations yet');
@@ -269,16 +283,17 @@ export default class ChatList {
     const me = this;
 
     $('.chat-search-box').on('input', function (e) {
-      const query = $(this).val().toLowerCase();
-      const showOnlyUnread = $('.unread-filter-checkbox').is(':checked');
-      me.filter_rooms(query, showOnlyUnread);
+      me.refresh_current_filter();
     });
 
     // Handle unread filter checkbox
     $('.unread-filter-checkbox').on('change', function (e) {
-      const showOnlyUnread = $(this).is(':checked');
-      const query = $('.chat-search-box').val().toLowerCase();
-      me.filter_rooms(query, showOnlyUnread);
+      me.refresh_current_filter();
+    });
+
+    // Handle "AI chats" filter checkbox
+    $('.ai-filter-checkbox').on('change', function (e) {
+      me.refresh_current_filter();
     });
 
     // Handle sort dropdown
@@ -372,11 +387,13 @@ export default class ChatList {
         return;
       }
 
-      frappe.utils.play_sound('chat-message-receive');
+      const isIncoming = res.type !== 'Outgoing';
+      if (isIncoming) {
+        frappe.utils.play_sound('chat-message-receive');
+      }
+      const content = res.content || '';
       const message =
-        res.content.length > 24
-          ? res.content.substring(0, 24) + '...'
-          : res.content;
+        content.length > 24 ? content.substring(0, 24) + '...' : content;
 
       chat_room_item[1].set_last_message(message, res.creation);
 
@@ -395,7 +412,7 @@ export default class ChatList {
             active_chat_space.receive_message(res, get_time(res.creation));
             mark_message_read(res.room);
           }
-        } else if (res.sender_user_no !== me.user_email) {
+        } else if (isIncoming && res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
 
@@ -403,7 +420,7 @@ export default class ChatList {
         me.refresh_current_filter();
       } else if ($('.chat-list').is(':visible')) {
         // Floating widget: user is on the chat list screen
-        if (res.sender_user_no !== me.user_email) {
+        if (isIncoming && res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
         me.reorder_room(chat_room_item);
@@ -418,13 +435,13 @@ export default class ChatList {
             active_chat_space.receive_message(res, get_time(res.creation));
             mark_message_read(res.room);
           }
-        } else if (res.sender_user_no !== me.user_email) {
+        } else if (isIncoming && res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
 
         me.reorder_room(chat_room_item);
       } else {
-        if (res.sender_user_no !== me.user_email) {
+        if (isIncoming && res.sender_user_no !== me.user_email) {
           chat_room_item[1].set_as_unread();
         }
         me.reorder_room(chat_room_item);
@@ -476,8 +493,9 @@ export default class ChatList {
 
   // Helper method to refresh current filter
   refresh_current_filter() {
-    const query = $('.chat-search-box').val().toLowerCase();
+    const query = ($('.chat-search-box').val() || '').toLowerCase();
     const showOnlyUnread = $('.unread-filter-checkbox').is(':checked');
-    this.filter_rooms(query, showOnlyUnread);
+    const showAiOnly = $('.ai-filter-checkbox').is(':checked');
+    this.filter_rooms(query, showOnlyUnread, showAiOnly);
   }
 }

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -22,6 +22,10 @@ export default class ChatSpace {
   setup() {
     this.$chat_space = $(document.createElement('div'));
     this.typing = false;
+    this.page_size = 30;
+    this.oldest_creation = null;
+    this.has_more = true;
+    this.loading_older = false;
     this.$chat_space.addClass('chat-space');
     this.setup_header();
     this.fetch_and_setup_messages();
@@ -60,8 +64,13 @@ export default class ChatSpace {
     try {
       const res = await get_messages(
         this.profile.room,
-        this.profile.user_email
+        this.profile.user_email,
+        this.page_size
       );
+      // res is ascending; oldest is the first row. More history exists if we
+      // got a full page.
+      this.oldest_creation = res && res.length ? res[0].creation : null;
+      this.has_more = !!(res && res.length === this.page_size);
       this.setup_messages(res);
       this.setup_actions();
       this.render();
@@ -84,9 +93,47 @@ export default class ChatSpace {
     this.$chat_space.append(this.$chat_space_container);
   }
 
+  // Which side a message bubble renders on.
+  _message_side(element) {
+    if (element.type === 'Outgoing') return 'recipient';
+    if (element.type === 'Incoming') return 'sender';
+    // Fallback: legacy/guest rows without an explicit type
+    if (element.sender_user_no === this.profile.user_email) return 'recipient';
+    if (
+      this.profile.room_type === 'Guest' &&
+      this.profile.is_admin === true &&
+      element.sender !== 'Guest'
+    ) {
+      return 'recipient';
+    }
+    return 'sender';
+  }
+
+  // Pure builder: returns the HTML for a list of messages (ascending), with
+  // date separators. Does not mutate this.prevMessage, so it is safe for both
+  // the initial render and prepending older pages.
+  build_messages_html(messages_list) {
+    let html = '';
+    let prev = {};
+    messages_list.forEach((element) => {
+      if ($.isEmptyObject(prev) || is_date_change(element.creation, prev.creation)) {
+        html += `<div class='date-line'><span>${__(
+          get_date_from_now(element.creation, 'space')
+        )}</span></div>`;
+      }
+      html += this.make_message(
+        element.content,
+        get_time(element.creation),
+        this._message_side(element),
+        element.sender,
+        element.sent_by
+      ).prop('outerHTML');
+      prev = element;
+    });
+    return html;
+  }
+
   make_messages_html(messages_list) {
-    this.prevMessage = {};
-    this.message_html = ``;
     if (this.profile.message) {
       messages_list.push(this.profile.message);
       send_message(
@@ -96,36 +143,10 @@ export default class ChatSpace {
         this.profile.user_email
       );
     }
-    messages_list.forEach((element) => {
-      const date_line_html = this.make_date_line_html(element.creation);
-      this.message_html += date_line_html;
-
-      let message_type;
-      if (element.type === 'Outgoing') {
-        message_type = 'recipient';
-      } else if (element.type === 'Incoming') {
-        message_type = 'sender';
-      } else {
-        // Fallback: legacy/guest rows without an explicit type
-        message_type = 'sender';
-        if (element.sender_user_no === this.profile.user_email) {
-          message_type = 'recipient';
-        } else if (this.profile.room_type === 'Guest') {
-          if (this.profile.is_admin === true && element.sender !== 'Guest') {
-            message_type = 'recipient';
-          }
-        }
-      }
-      this.message_html += this.make_message(
-        element.content,
-        get_time(element.creation),
-        message_type,
-        element.sender,
-        element.sent_by
-      ).prop('outerHTML');
-
-      this.prevMessage = element;
-    });
+    this.message_html = this.build_messages_html(messages_list);
+    this.prevMessage = messages_list.length
+      ? messages_list[messages_list.length - 1]
+      : {};
   }
 
   make_date_line_html(dateObj) {
@@ -428,19 +449,16 @@ export default class ChatSpace {
   }
 
   receive_message(res, time) {
-    // Don't add message if it's from the current user (avoid duplicates)
-    if (res.sender_user_no === this.profile.user_email) {
+    // Skip my own just-sent message — it was already appended optimistically.
+    if (res.type === 'Outgoing' && res.owner && res.owner === frappe.session.user) {
+      return;
+    }
+    // Legacy/guest rows without an explicit type: dedupe by counterpart number.
+    if (!res.type && res.sender_user_no === this.profile.user_email) {
       return;
     }
 
-    let chat_type = 'sender';
-
-    // Determine message type based on room type
-    if (this.profile.room_type === 'Guest') {
-      if (this.profile.is_admin === true && res.user !== 'Guest') {
-        chat_type = 'recipient';
-      }
-    }
+    const chat_type = this._message_side(res);
 
     // Add date separator if needed
     const date_line_html = this.make_date_line_html(res.creation);
@@ -450,11 +468,15 @@ export default class ChatSpace {
 
     // Add the new message
     this.$chat_space_container.append(
-      this.make_message(res.content, time, chat_type, res.user)
+      this.make_message(res.content, time, chat_type, res.user, res.sent_by)
     );
 
-    // Scroll to bottom to show new message
-    scroll_to_bottom(this.$chat_space_container);
+    // Only auto-scroll if the user is already near the bottom, so we don't
+    // yank them away while they're reading older history.
+    const sc = this.$chat_space_container[0];
+    if (sc.scrollHeight - sc.scrollTop - sc.clientHeight < 150) {
+      scroll_to_bottom(this.$chat_space_container);
+    }
 
     // Update previous message for date line calculation
     this.prevMessage = res;
@@ -477,7 +499,40 @@ export default class ChatSpace {
 
     this.setup_events();
 
+    // Lazy-load older messages when the user scrolls near the top.
+    const me = this;
+    this.$chat_space_container.off('scroll.lazy').on('scroll.lazy', function () {
+      if (this.scrollTop <= 40) me.load_older_messages();
+    });
+
     scroll_to_bottom(this.$chat_space_container);
+  }
+
+  async load_older_messages() {
+    if (this.loading_older || !this.has_more || !this.oldest_creation) return;
+    this.loading_older = true;
+    try {
+      const older = await get_messages(
+        this.profile.room,
+        this.profile.user_email,
+        this.page_size,
+        this.oldest_creation
+      );
+      if (older && older.length) {
+        const sc = this.$chat_space_container[0];
+        const prevHeight = sc.scrollHeight;
+        this.$chat_space_container.prepend(this.build_messages_html(older));
+        // Keep the viewport anchored on the same message after prepending.
+        sc.scrollTop = sc.scrollHeight - prevHeight;
+        this.oldest_creation = older[0].creation;
+        this.has_more = older.length === this.page_size;
+      } else {
+        this.has_more = false;
+      }
+    } catch (error) {
+      console.error('Error loading older messages:', error);
+    }
+    this.loading_older = false;
   }
 
   async refresh_messages() {

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -68,8 +68,8 @@ export default class ChatSpace {
         this.page_size
       );
       // res is ascending; oldest is the first row. More history exists if we
-      // got a full page.
-      this.oldest_creation = res && res.length ? res[0].creation : null;
+      // got a full page. Track the composite cursor for the next older page.
+      this._set_oldest_cursor(res);
       this.has_more = !!(res && res.length === this.page_size);
       this.setup_messages(res);
       this.setup_actions();
@@ -449,6 +449,13 @@ export default class ChatSpace {
   }
 
   receive_message(res, time) {
+    // The same message can arrive on both the per-room channel and the
+    // owner-scoped `latest_chat_updates` channel — dedupe by message id.
+    if (res.message_id) {
+      this._seen_ids = this._seen_ids || new Set();
+      if (this._seen_ids.has(res.message_id)) return;
+      this._seen_ids.add(res.message_id);
+    }
     // Skip my own just-sent message — it was already appended optimistically.
     if (res.type === 'Outgoing' && res.owner && res.owner === frappe.session.user) {
       return;
@@ -508,23 +515,43 @@ export default class ChatSpace {
     scroll_to_bottom(this.$chat_space_container);
   }
 
+  // Track the composite "older than" cursor (creation, name, kind) from the
+  // oldest row of the current page (rows are ascending, so index 0).
+  _set_oldest_cursor(rows) {
+    if (rows && rows.length) {
+      const o = rows[0];
+      this._oldest = { before: o.creation, before_name: o.name, before_kind: o.kind };
+      this.oldest_creation = o.creation;
+    } else {
+      this._oldest = null;
+      this.oldest_creation = null;
+    }
+  }
+
   async load_older_messages() {
-    if (this.loading_older || !this.has_more || !this.oldest_creation) return;
+    if (this.loading_older || !this.has_more || !this._oldest) return;
     this.loading_older = true;
     try {
+      const prevOldestCreation = this._oldest.before;
       const older = await get_messages(
         this.profile.room,
         this.profile.user_email,
         this.page_size,
-        this.oldest_creation
+        this._oldest
       );
       if (older && older.length) {
         const sc = this.$chat_space_container[0];
         const prevHeight = sc.scrollHeight;
+        // If the page boundary is the same day, the existing leading date
+        // separator is now redundant (the older page re-establishes it) — drop it.
+        const lastOld = older[older.length - 1];
+        if (prevOldestCreation && !is_date_change(prevOldestCreation, lastOld.creation)) {
+          this.$chat_space_container.children('.date-line').first().remove();
+        }
         this.$chat_space_container.prepend(this.build_messages_html(older));
         // Keep the viewport anchored on the same message after prepending.
         sc.scrollTop = sc.scrollHeight - prevHeight;
-        this.oldest_creation = older[0].creation;
+        this._set_oldest_cursor(older);
         this.has_more = older.length === this.page_size;
       } else {
         this.has_more = false;

--- a/whatsapp_chat/public/js/components/chat_utils.js
+++ b/whatsapp_chat/public/js/components/chat_utils.js
@@ -56,12 +56,14 @@ async function get_rooms(email) {
   return await res.message;
 }
 
-async function get_messages(room, user_no) {
+async function get_messages(room, user_no, limit = 30, before = null) {
   const res = await frappe.call({
     method: 'whatsapp_chat.api.message.get_all',
     args: {
       room: room,
       user_no: user_no,
+      limit: limit,
+      before: before,
     },
   });
   return await res.message;

--- a/whatsapp_chat/public/js/components/chat_utils.js
+++ b/whatsapp_chat/public/js/components/chat_utils.js
@@ -56,14 +56,17 @@ async function get_rooms(email) {
   return await res.message;
 }
 
-async function get_messages(room, user_no, limit = 30, before = null) {
+async function get_messages(room, user_no, limit = 30, cursor = null) {
+  cursor = cursor || {};
   const res = await frappe.call({
     method: 'whatsapp_chat.api.message.get_all',
     args: {
       room: room,
       user_no: user_no,
       limit: limit,
-      before: before,
+      before: cursor.before || null,
+      before_name: cursor.before_name || null,
+      before_kind: cursor.before_kind != null ? cursor.before_kind : null,
     },
   });
   return await res.message;


### PR DESCRIPTION
## Summary
Foundational chat improvements on the full-screen WhatsApp page: search by phone number, message pagination (lazy/infinite scroll), reliable live updates for incoming and outgoing messages, the wiring for an "AI chats" filter, and a server-enforced reply-permission model. Permission/AI logic that other apps reuse lives here so there's a single source of truth.

## What changed
Search by phone number — chat_list.js filter_rooms() now matches contact name OR phone digits (previously name-only).
"AI chats" filter (UI) — new checkbox in the filter bar; reads an ai_replied flag per chat (populated by leanerp_whatsapp_chat's contacts.get override) and filters the list. Wiring centralised through refresh_current_filter().
Lazy loading — api/message.py get_all(room, user_no, limit=30, before=None) returns the newest page (ascending), with a before creation cursor; chat_space.js renders the newest page and prepends older messages on scroll-to-top, preserving viewport position. chat_utils.get_messages passes limit/before. (Includes a guard normalising the JS "null" string cursor that frappe.call produces.)
Live auto-update — update_contact_on_message publishes a per-room realtime event for every message (in + out, carrying type/owner/message_id); chat_space.receive_message renders the correct side, de-dupes the sender's own optimistic echo, and only auto-scrolls when already near the bottom. Outgoing messages no longer falsely mark chats unread or play the receive sound.
Reply permissions (server, shared) — MANAGER_ROLES, can_reply_to_contact(), assert_can_reply_number(). send is blocked for non-repliers; mark_as_read silently skips for read-only viewers so it can't clear an owner's unread badge.