### PR TITLE
Feat: SRO-2026-06-00162 Make whatsapp_chat standalone: own its chat-window setting 

### DIFF
--- a/whatsapp_chat/api/contacts.py
+++ b/whatsapp_chat/api/contacts.py
@@ -5,12 +5,13 @@ from frappe.utils import add_to_date, cint, now_datetime
 def _get_chat_window_days(default_days: int = 7) -> int:
     """Window (in days) for the chat-list 'recent incoming message' filter.
 
-    Sourced from the Leanerp WhatsApp Settings single. Falls back to the default
-    when the value/doctype is unset or non-positive so the filter stays active.
+    Sourced from whatsapp_chat's own WhatsApp Chat Settings single (so the app
+    needs only frappe_whatsapp). Falls back to the default when the value/doctype
+    is unset or non-positive so the filter stays active.
     """
     try:
         days = cint(
-            frappe.db.get_single_value("Leanerp WhatsApp Settings", "chat_list_window_days")
+            frappe.db.get_single_value("WhatsApp Chat Settings", "chat_list_window_days")
         )
     except Exception:
         return default_days

--- a/whatsapp_chat/hooks.py
+++ b/whatsapp_chat/hooks.py
@@ -4,7 +4,7 @@ app_publisher = "shridhar patil"
 app_description = "Chat app for whatsapp"
 app_email = "shridharpatil2792@gmail.com"
 app_license = "unlicense"
-# required_apps = []
+required_apps = ["ptstdm/frappe_whatsapp"]
 
 # Includes in <head>
 # ------------------

--- a/whatsapp_chat/patches.txt
+++ b/whatsapp_chat/patches.txt
@@ -5,4 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 whatsapp_chat.patches.25_09_2025_set_lead_owner_in_whatsapp_contacts #1
-whatsapp_chat.patches.24_06_2026_migrate_chat_window_days
+whatsapp_chat.patches.24_06_2026_migrate_chat_window_days #1

--- a/whatsapp_chat/patches.txt
+++ b/whatsapp_chat/patches.txt
@@ -5,3 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 whatsapp_chat.patches.25_09_2025_set_lead_owner_in_whatsapp_contacts #1
+whatsapp_chat.patches.24_06_2026_migrate_chat_window_days

--- a/whatsapp_chat/patches/24_06_2026_migrate_chat_window_days.py
+++ b/whatsapp_chat/patches/24_06_2026_migrate_chat_window_days.py
@@ -2,8 +2,13 @@
 
 `chat_list_window_days` used to live on `Leanerp WhatsApp Settings` (leanerp_whatsapp).
 It now lives on `WhatsApp Chat Settings` so whatsapp_chat needs only frappe_whatsapp.
-Copy the configured value across if the old Single exists, so an already-tuned
-value (e.g. 100) isn't reset to the default on upgrade. No-op on a leanerp-free site.
+Copy the configured value across so an already-tuned value isn't reset to the default
+on upgrade. No-op on a leanerp-free site (the row simply won't exist).
+
+Read straight from `tabSingles` rather than `get_single_value`: the field has been
+removed from the Leanerp WhatsApp Settings doctype, and model-sync strips it from the
+meta *before* this post-model-sync patch runs — so `get_single_value` would raise
+"field does not exist". The raw single value survives that removal and stays readable.
 """
 
 import frappe
@@ -11,15 +16,10 @@ from frappe.utils import cint
 
 
 def execute():
-    if not frappe.db.exists("DocType", "Leanerp WhatsApp Settings"):
-        return
-
-    try:
-        old_value = cint(
-            frappe.db.get_single_value("Leanerp WhatsApp Settings", "chat_list_window_days")
-        )
-    except Exception:
-        return
-
+    row = frappe.db.sql(
+        """SELECT value FROM tabSingles WHERE doctype = %s AND field = %s""",
+        ("Leanerp WhatsApp Settings", "chat_list_window_days"),
+    )
+    old_value = cint(row[0][0]) if row and row[0][0] is not None else 0
     if old_value > 0:
         frappe.db.set_single_value("WhatsApp Chat Settings", "chat_list_window_days", old_value)

--- a/whatsapp_chat/patches/24_06_2026_migrate_chat_window_days.py
+++ b/whatsapp_chat/patches/24_06_2026_migrate_chat_window_days.py
@@ -1,0 +1,25 @@
+"""Carry the chat-list window from the legacy leanerp Single to whatsapp_chat's own.
+
+`chat_list_window_days` used to live on `Leanerp WhatsApp Settings` (leanerp_whatsapp).
+It now lives on `WhatsApp Chat Settings` so whatsapp_chat needs only frappe_whatsapp.
+Copy the configured value across if the old Single exists, so an already-tuned
+value (e.g. 100) isn't reset to the default on upgrade. No-op on a leanerp-free site.
+"""
+
+import frappe
+from frappe.utils import cint
+
+
+def execute():
+    if not frappe.db.exists("DocType", "Leanerp WhatsApp Settings"):
+        return
+
+    try:
+        old_value = cint(
+            frappe.db.get_single_value("Leanerp WhatsApp Settings", "chat_list_window_days")
+        )
+    except Exception:
+        return
+
+    if old_value > 0:
+        frappe.db.set_single_value("WhatsApp Chat Settings", "chat_list_window_days", old_value)

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -79,10 +79,6 @@ export default class ChatList {
         <input type='checkbox' class='unread-filter-checkbox'>
         <span class='checkmark'>${__('Unread')}</span>
       </label>
-      <label class='unread-filter-container' title='${__('Show chats the AI agent has replied to')}'>
-        <input type='checkbox' class='ai-filter-checkbox'>
-        <span class='checkmark'>${__('AI chats')}</span>
-      </label>
     `;
   }
 
@@ -291,11 +287,6 @@ export default class ChatList {
       me.refresh_current_filter();
     });
 
-    // Handle "AI chats" filter checkbox
-    $('.ai-filter-checkbox').on('change', function (e) {
-      me.refresh_current_filter();
-    });
-
     // Handle sort dropdown
     $('.wa-filter-sort').on('change', function () {
       me.sort_by = $(this).val();
@@ -495,7 +486,7 @@ export default class ChatList {
   refresh_current_filter() {
     const query = ($('.chat-search-box').val() || '').toLowerCase();
     const showOnlyUnread = $('.unread-filter-checkbox').is(':checked');
-    const showAiOnly = $('.ai-filter-checkbox').is(':checked');
-    this.filter_rooms(query, showOnlyUnread, showAiOnly);
+    // The "AI chats" filter is hidden (not functional) — never restrict to AI-only.
+    this.filter_rooms(query, showOnlyUnread, false);
   }
 }

--- a/whatsapp_chat/whatsapp_chat/doctype/whatsapp_chat_settings/whatsapp_chat_settings.json
+++ b/whatsapp_chat/whatsapp_chat/doctype/whatsapp_chat_settings/whatsapp_chat_settings.json
@@ -35,13 +35,6 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "All",
-   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/whatsapp_chat/whatsapp_chat/doctype/whatsapp_chat_settings/whatsapp_chat_settings.json
+++ b/whatsapp_chat/whatsapp_chat/doctype/whatsapp_chat_settings/whatsapp_chat_settings.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-06-24 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "chat_list_window_days"
+ ],
+ "fields": [
+  {
+   "default": "7",
+   "description": "Show a contact in the WhatsApp chat list only if it has an incoming message within this many days. Blank or 0 falls back to 7.",
+   "fieldname": "chat_list_window_days",
+   "fieldtype": "Int",
+   "label": "Chat List Window (Days)"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-06-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Whatsapp Chat",
+ "name": "WhatsApp Chat Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "All",
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/whatsapp_chat/whatsapp_chat/doctype/whatsapp_chat_settings/whatsapp_chat_settings.py
+++ b/whatsapp_chat/whatsapp_chat/doctype/whatsapp_chat_settings/whatsapp_chat_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, shridhar patil and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WhatsAppChatSettings(Document):
+	pass


### PR DESCRIPTION
## Summary
Removes whatsapp_chat's dependency on `leanerp_whatsapp` so it runs with only `frappe_whatsapp`.
Adds a `WhatsApp Chat Settings` Single it owns, and hides the non-functional "AI chats" filter.

## Why
`whatsapp_chat/api/contacts.py` read `chat_list_window_days` from **leanerp_whatsapp's**
`Leanerp WhatsApp Settings` Single (a backwards/upward dependency). For the apps to install and
run independently, whatsapp_chat must own this setting.

## What changed
### New Single — `WhatsApp Chat Settings`
- Holds `chat_list_window_days` (default 7), restricted to **System Manager** (it's admin config,
  read server-side via `get_single_value`).

### Read from own Single — `api/contacts.py`
- `_get_chat_window_days()` now reads `WhatsApp Chat Settings` instead of `Leanerp WhatsApp Settings`
  (keeps the try/except → default guard).

### Migration patch — `patches/24_06_2026_migrate_chat_window_days.py` (new)
- Carries the configured value across on upgrade. Reads the legacy value **directly from
  `tabSingles`** (not `get_single_value`, which validates against the doctype meta — the field has
  been removed from Leanerp WhatsApp Settings, and model-sync strips it before this post-sync patch
  runs). No-op on a leanerp-free site.

### Dependency declaration — `hooks.py`
- `required_apps = ["ptstdm/frappe_whatsapp"]`.

### Hide the non-functional "AI chats" filter — `public/js/components/chat_list.js`
- Removed the "AI chats" checkbox + its handler; the chat list no longer offers an AI-only filter.
  `filter_rooms(...)` is left intact (always receives `false`) so it can be re-enabled later.

## Testing
- `node --check` / `py_compile`; rebuilt assets (`bench build --app whatsapp_chat`).
- Migration patch verified end-to-end: with the legacy value present in `tabSingles`, the patch
  recovers it into `WhatsApp Chat Settings` even after the source field is removed from the meta.
- `_get_chat_window_days()` reads the new Single; `grep` confirms no `Leanerp WhatsApp Settings`
  read remains in the app (outside the transitional patch).
- Confirmed the rebuilt bundle no longer contains the AI filter markup.

## Notes
- Pairs with leanerp_whatsapp PR (`meta_api`).
- The legacy `chat_list_window_days` field is removed from Leanerp WhatsApp Settings in that PR; this
  patch reads the raw `tabSingles` value so the two PRs are order-independent on upgrade.


