### PR TITLE
fix(chat): targeted set_value + retry for update_contact_on_message

### DIFF
--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -318,8 +318,8 @@ def _update_contact_with_retry(name, values):
             frappe.db.rollback()
             if attempt == _CONTACT_UPDATE_RETRY_ATTEMPTS - 1:
                 frappe.log_error(
-                    "update_contact_on_message: contact update failed after retries",
-                    f"WhatsApp Contact: {name}\n{frappe.get_traceback()}",
+                    title="update_contact_on_message: contact update failed after retries",
+                    message=f"WhatsApp Contact: {name}\n{frappe.get_traceback()}",
                 )
                 return
             if not frappe.local.flags.in_test:

--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -1,10 +1,20 @@
 import mimetypes
+import random
+import time
 
 import frappe
 
 # Roles that may reply to any chat. Everyone can *view* every chat; replying is
 # restricted to managers, the chat's owner, or unassigned (shared-pool) chats.
 MANAGER_ROLES = {"System Manager", "Sales Manager", "Sales Co-ordinator"}
+
+# update_contact_on_message runs in a background job and, on `innodb_snapshot_isolation=ON`, a
+# concurrent committed write to the same WhatsApp Contact makes the get_doc->save read-modify-write
+# raise 1020 (QueryDeadlockError). A targeted set_value (blind UPDATE, no optimistic-lock read) removes
+# that class; the retry belt still covers a transient 1213/1205. Best-effort UI state — the next
+# message re-syncs it — so log-only on exhaustion.
+_CONTACT_UPDATE_RETRY_ATTEMPTS = 3
+_CONTACT_UPDATE_BACKOFF_BASE = 0.1  # seconds; full-jitter exponential backoff
 
 
 def _wa_normalized_col(direction):
@@ -295,25 +305,49 @@ def last_message(doc, method):
     )
 
 
+def _update_contact_with_retry(name, values):
+    """Apply a targeted WhatsApp Contact update, retrying through a transient 1213/1205 lock conflict.
+    A blind set_value (no optimistic-lock read) already removes the 1020 RMW class; this belt covers the
+    rarer deadlock/lock-wait. Best-effort UI state (the next message re-syncs), so log-only on exhaustion."""
+    for attempt in range(_CONTACT_UPDATE_RETRY_ATTEMPTS):
+        try:
+            frappe.db.set_value("WhatsApp Contact", name, values)
+            frappe.db.commit()
+            return
+        except (frappe.QueryDeadlockError, frappe.QueryTimeoutError):
+            frappe.db.rollback()
+            if attempt == _CONTACT_UPDATE_RETRY_ATTEMPTS - 1:
+                frappe.log_error(
+                    "update_contact_on_message: contact update failed after retries",
+                    f"WhatsApp Contact: {name}\n{frappe.get_traceback()}",
+                )
+                return
+            if not frappe.local.flags.in_test:
+                time.sleep(random.uniform(0, _CONTACT_UPDATE_BACKOFF_BASE * (2**attempt)))
+
+
 def update_contact_on_message(mobile_no, message, message_type, profile_name, is_outgoing, owner=None, message_id=None):
-    contact_name = frappe.db.get_value(
+    contact = frappe.db.get_value(
         "WhatsApp Contact",
-        filters={"mobile_no": ["like", f"%{mobile_no}"]},  
+        filters={"mobile_no": ["like", f"%{mobile_no}"]},
+        fieldname=["name", "contact_name", "email"],
         order_by="modified desc",
+        as_dict=True,
     )
-    if contact_name:
-        chat_doc = frappe.get_doc("WhatsApp Contact", contact_name)
-        chat_doc.last_message = message
-        chat_doc.message_type = message_type
+    if contact:
+        # Targeted UPDATE (no get_doc read) so a concurrent committed write to this row can't raise
+        # 1020 (ER_CHECKREAD) on the read-modify-write. The WhatsApp Contact update path has no
+        # controller lifecycle / doc_event hooks (only after_insert, which runs on insert), so a blind
+        # set_value is behaviour-equivalent to the previous db_update()/save() here.
+        values = {"last_message": message, "message_type": message_type}
         if not is_outgoing:
-            chat_doc.is_read = 0
-        current_contact_name = chat_doc.contact_name or ""
+            values["is_read"] = 0
+        current_contact_name = contact.contact_name or ""
         if current_contact_name[-10:] == mobile_no and profile_name:
-            chat_doc.contact_name = profile_name
-        if is_outgoing:
-            chat_doc.db_update()
-        else:
-            chat_doc.save(ignore_permissions=True)
+            values["contact_name"] = profile_name
+        _update_contact_with_retry(contact.name, values)
+        room_name = contact.name
+        room_email = contact.email
     else:
         chat_doc = frappe.get_doc(
             {
@@ -326,13 +360,15 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
             }
         )
         chat_doc.insert(ignore_permissions=True)
+        room_name = chat_doc.name
+        room_email = chat_doc.email
 
     # Push every message (incoming AND outgoing) so the open chat reflects
     # AI/other-agent/template replies live and the list preview/order updates.
     payload = {
         "content": message,
         "creation": frappe.utils.now(),
-        "room": chat_doc.name,
+        "room": room_name,
         "type": message_type,
         "owner": owner,
         "message_id": message_id,
@@ -341,12 +377,12 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
 
     # Per-room channel: any open ChatSpace (including managers viewing another
     # agent's chat) subscribes to `this.profile.room` and appends live.
-    frappe.publish_realtime(chat_doc.name, payload)
+    frappe.publish_realtime(room_name, payload)
 
     # List channel: updates the owner's chat-list preview / order / unread badge.
-    if chat_doc.email:
+    if room_email:
         frappe.publish_realtime(
             "latest_chat_updates",
             payload,
-            user=chat_doc.email,
+            user=room_email,
         )

--- a/whatsapp_chat/api/test_message.py
+++ b/whatsapp_chat/api/test_message.py
@@ -1,0 +1,119 @@
+from unittest.mock import ANY, MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from whatsapp_chat.api.message import _update_contact_with_retry, update_contact_on_message
+
+
+class TestUpdateContactOnMessage(FrappeTestCase):
+    """FIX 4 (2026-07-01 triage): update_contact_on_message ran a get_doc -> save read-modify-write on
+    WhatsApp Contact inside a background job, so on `innodb_snapshot_isolation=ON` a concurrent committed
+    write raised 1020 (ER_CHECKREAD). It now does a targeted set_value (a blind UPDATE with no
+    optimistic-lock read) behind a bounded retry. Fully mocked — no site data required."""
+
+    def test_update_retries_then_succeeds(self):
+        # One 1020 then success: set_value is retried, committed once, nothing logged.
+        calls = {"n": 0}
+
+        def flaky_set_value(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise frappe.QueryDeadlockError("1020 Record has changed in tabWhatsApp Contact")
+
+        with (
+            patch.object(frappe.db, "set_value", side_effect=flaky_set_value),
+            patch.object(frappe.db, "commit") as mock_commit,
+            patch.object(frappe.db, "rollback") as mock_rollback,
+            patch("whatsapp_chat.api.message.time.sleep"),
+            patch("frappe.log_error") as mock_log,
+        ):
+            _update_contact_with_retry("WA-CONTACT-1", {"last_message": "hi"})
+
+        self.assertEqual(calls["n"], 2, "set_value retried once after the 1020")
+        self.assertEqual(mock_rollback.call_count, 1)
+        mock_commit.assert_called_once()
+        mock_log.assert_not_called()
+
+    def test_update_logs_and_returns_on_exhaustion(self):
+        # Every attempt deadlocks: log once and return (best-effort UI state, the next message re-syncs);
+        # never raise (it would just fail the background job).
+        def always_deadlock(*args, **kwargs):
+            raise frappe.QueryDeadlockError("1020")
+
+        with (
+            patch.object(frappe.db, "set_value", side_effect=always_deadlock),
+            patch.object(frappe.db, "commit") as mock_commit,
+            patch.object(frappe.db, "rollback"),
+            patch("whatsapp_chat.api.message.time.sleep"),
+            patch("frappe.log_error") as mock_log,
+        ):
+            # Must not raise.
+            _update_contact_with_retry("WA-CONTACT-1", {"last_message": "hi"})
+
+        mock_commit.assert_not_called()
+        self.assertEqual(mock_log.call_count, 1, "logs exactly once on exhaustion")
+
+    def test_existing_contact_uses_targeted_set_value_no_get_doc(self):
+        # Structural change: an existing contact is updated via a blind set_value — NOT a get_doc + save
+        # — so there is no read-modify-write to raise a 1020. Incoming clears is_read; profile_name that
+        # matches the bare-number contact_name upgrades it; realtime uses the fetched name/email.
+        contact = frappe._dict({"name": "WA-CONTACT-1", "contact_name": "9998887776", "email": "a@x.com"})
+        set_value_calls = []
+
+        with (
+            patch.object(frappe.db, "get_value", return_value=contact),
+            patch.object(
+                frappe.db, "set_value", side_effect=lambda dt, name, vals: set_value_calls.append((name, vals))
+            ),
+            patch.object(frappe.db, "commit"),
+            patch("frappe.get_doc") as mock_get_doc,
+            patch("frappe.publish_realtime") as mock_publish,
+            patch("frappe.utils.now", return_value="2026-07-01 00:00:00"),
+        ):
+            update_contact_on_message(
+                mobile_no="9998887776",
+                message="hi",
+                message_type="Incoming",
+                profile_name="Cust",
+                is_outgoing=False,
+                owner="agent@x.com",
+                message_id="MSG-1",
+            )
+
+        mock_get_doc.assert_not_called()  # the RMW (get_doc -> save) that raised the 1020 is gone
+        self.assertEqual(len(set_value_calls), 1)
+        name, vals = set_value_calls[0]
+        self.assertEqual(name, "WA-CONTACT-1")
+        self.assertEqual(vals["last_message"], "hi")
+        self.assertEqual(vals["message_type"], "Incoming")
+        self.assertEqual(vals["is_read"], 0, "incoming clears is_read")
+        self.assertEqual(vals["contact_name"], "Cust", "profile_name upgrades a bare-number contact_name")
+        # Per-room publish + list-channel publish (email present) both fire with the fetched identifiers.
+        mock_publish.assert_any_call("WA-CONTACT-1", ANY)
+        mock_publish.assert_any_call("latest_chat_updates", ANY, user="a@x.com")
+
+    def test_missing_contact_inserts_new(self):
+        # No existing contact -> the insert path (get_doc(dict).insert()) still runs; no set_value.
+        fake_new = MagicMock()
+        fake_new.name = "WA-CONTACT-NEW"
+        fake_new.email = None
+
+        with (
+            patch.object(frappe.db, "get_value", return_value=None),
+            patch("frappe.get_doc", return_value=fake_new),
+            patch.object(frappe.db, "set_value") as mock_set_value,
+            patch("frappe.publish_realtime") as mock_publish,
+            patch("frappe.utils.now", return_value="2026-07-01 00:00:00"),
+        ):
+            update_contact_on_message(
+                mobile_no="9998887776",
+                message="hi",
+                message_type="Incoming",
+                profile_name="Cust",
+                is_outgoing=False,
+            )
+
+        fake_new.insert.assert_called_once()
+        mock_set_value.assert_not_called()
+        mock_publish.assert_any_call("WA-CONTACT-NEW", ANY)

--- a/whatsapp_chat/api/test_message.py
+++ b/whatsapp_chat/api/test_message.py
@@ -7,10 +7,10 @@ from whatsapp_chat.api.message import _update_contact_with_retry, update_contact
 
 
 class TestUpdateContactOnMessage(FrappeTestCase):
-    """FIX 4 (2026-07-01 triage): update_contact_on_message ran a get_doc -> save read-modify-write on
-    WhatsApp Contact inside a background job, so on `innodb_snapshot_isolation=ON` a concurrent committed
-    write raised 1020 (ER_CHECKREAD). It now does a targeted set_value (a blind UPDATE with no
-    optimistic-lock read) behind a bounded retry. Fully mocked — no site data required."""
+    """Regression tests for update_contact_on_message: the existing-contact path uses a targeted
+    set_value (a blind UPDATE with no optimistic-lock read) instead of a get_doc -> save
+    read-modify-write, so a concurrent write can't raise 1020 (ER_CHECKREAD) under snapshot isolation;
+    a bounded retry covers a transient 1213/1205. Fully mocked — no site data required."""
 
     def test_update_retries_then_succeeds(self):
         # One 1020 then success: set_value is retried, committed once, nothing logged.


### PR DESCRIPTION
On innodb_snapshot_isolation=ON, update_contact_on_message's get_doc -> save read-modify-write on WhatsApp Contact raised 1020 (ER_CHECKREAD) in its background job (the whatsapp_chat.api.message.update_contact_on_message cluster in the 06-30 triage). Replace the RMW on the existing-contact path with a targeted frappe.db.set_value (a blind UPDATE with no optimistic-lock read, so no 1020), behind a bounded _update_contact_with_retry for a transient 1213/1205. Safe: the WhatsApp Contact update path has no controller/doc_event hooks (only after_insert).

Tests: TestUpdateContactOnMessage (retry-then-succeed / log-and-return on exhaustion / no get_doc RMW / insert path).