### PR TITLE
fix(chat): guard update_contact_on_message insert against the mobile_…

### DIFF
--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -56,7 +56,9 @@ def assert_can_reply_number(to):
 
 
 @frappe.whitelist()
-def get_all(room: str, user_no: str, limit=30, before=None, before_name=None, before_kind=None):
+def get_all(
+    room: str, user_no: str, limit=30, before=None, before_name=None, before_kind=None
+):
     """Get a page of a room's messages for lazy/infinite scroll.
 
     Returns the newest `limit` rows (text + attachment), in ascending order for
@@ -95,7 +97,9 @@ def get_all(room: str, user_no: str, limit=30, before=None, before_name=None, be
     if to_col and from_col:
         contact_match = f"(m.{to_col} = %(user_no)s OR m.{from_col} = %(user_no)s)"
     else:
-        contact_match = "(RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)"
+        contact_match = (
+            "(RIGHT(m.`to`, 10) = %(user_no)s OR RIGHT(m.`from`, 10) = %(user_no)s)"
+        )
 
     rows = frappe.db.sql(
         f"""
@@ -323,10 +327,20 @@ def _update_contact_with_retry(name, values):
                 )
                 return
             if not frappe.local.flags.in_test:
-                time.sleep(random.uniform(0, _CONTACT_UPDATE_BACKOFF_BASE * (2**attempt)))
+                time.sleep(
+                    random.uniform(0, _CONTACT_UPDATE_BACKOFF_BASE * (2**attempt))
+                )
 
 
-def update_contact_on_message(mobile_no, message, message_type, profile_name, is_outgoing, owner=None, message_id=None):
+def update_contact_on_message(
+    mobile_no,
+    message,
+    message_type,
+    profile_name,
+    is_outgoing,
+    owner=None,
+    message_id=None,
+):
     contact = frappe.db.get_value(
         "WhatsApp Contact",
         filters={"mobile_no": ["like", f"%{mobile_no}"]},

--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -334,11 +334,45 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
         order_by="modified desc",
         as_dict=True,
     )
+    if not contact:
+        try:
+            chat_doc = frappe.get_doc(
+                {
+                    "doctype": "WhatsApp Contact",
+                    "mobile_no": mobile_no,
+                    "last_message": message,
+                    "contact_name": profile_name or mobile_no,
+                    "message_type": message_type,
+                    "is_read": 0,
+                }
+            )
+            chat_doc.insert(ignore_permissions=True)
+            room_name = chat_doc.name
+            room_email = chat_doc.email
+        except frappe.UniqueValidationError:
+            # TOCTOU race: a concurrent message for the same NEW number passed the same existence check
+            # above and inserted first, so this insert trips the mobile_no unique index. Roll back the
+            # failed insert and fall through to the existing-contact path against the row the winner
+            # created, so this message still updates the contact and fires its realtime publish. (The
+            # insert branch was the gap the 07-01 update-branch retry fix left open.)
+            frappe.db.rollback()
+            contact = frappe.db.get_value(
+                "WhatsApp Contact",
+                filters={"mobile_no": ["like", f"%{mobile_no}"]},
+                fieldname=["name", "contact_name", "email"],
+                order_by="modified desc",
+                as_dict=True,
+            )
+            if not contact:
+                # No winning row to fall back to (deleted meanwhile, or a non-race integrity error) —
+                # re-raise so a genuine failure isn't silently swallowed as if it were the race.
+                raise
+
     if contact:
-        # Targeted UPDATE (no get_doc read) so a concurrent committed write to this row can't raise
-        # 1020 (ER_CHECKREAD) on the read-modify-write. The WhatsApp Contact update path has no
-        # controller lifecycle / doc_event hooks (only after_insert, which runs on insert), so a blind
-        # set_value is behaviour-equivalent to the previous db_update()/save() here.
+        # Existing (or raced-to-existing) contact. Targeted UPDATE (no get_doc read) so a concurrent
+        # committed write to this row can't raise 1020 (ER_CHECKREAD) on the read-modify-write. The
+        # WhatsApp Contact update path has no controller lifecycle / doc_event hooks (only after_insert,
+        # which runs on insert), so a blind set_value is behaviour-equivalent to a db_update()/save().
         values = {"last_message": message, "message_type": message_type}
         if not is_outgoing:
             values["is_read"] = 0
@@ -348,20 +382,6 @@ def update_contact_on_message(mobile_no, message, message_type, profile_name, is
         _update_contact_with_retry(contact.name, values)
         room_name = contact.name
         room_email = contact.email
-    else:
-        chat_doc = frappe.get_doc(
-            {
-                "doctype": "WhatsApp Contact",
-                "mobile_no": mobile_no,
-                "last_message": message,
-                "contact_name": profile_name or mobile_no,
-                "message_type": message_type,
-                "is_read": 0,
-            }
-        )
-        chat_doc.insert(ignore_permissions=True)
-        room_name = chat_doc.name
-        room_email = chat_doc.email
 
     # Push every message (incoming AND outgoing) so the open chat reflects
     # AI/other-agent/template replies live and the list preview/order updates.

--- a/whatsapp_chat/api/test_message.py
+++ b/whatsapp_chat/api/test_message.py
@@ -117,3 +117,69 @@ class TestUpdateContactOnMessage(FrappeTestCase):
         fake_new.insert.assert_called_once()
         mock_set_value.assert_not_called()
         mock_publish.assert_any_call("WA-CONTACT-NEW", ANY)
+
+    def test_insert_race_falls_back_to_existing_contact(self):
+        # TOCTOU: no contact at first, but a concurrent job for the same NEW number inserts before us, so
+        # our insert trips the mobile_no unique index (UniqueValidationError). We must roll back, re-look
+        # up the winner's row, and take the existing-contact path (targeted set_value + realtime publish
+        # with the winner's identifiers) — never crash the background job.
+        winner = frappe._dict({"name": "WA-CONTACT-WIN", "contact_name": "9998887776", "email": "w@x.com"})
+        new_doc = MagicMock()
+        new_doc.insert.side_effect = frappe.UniqueValidationError(
+            "WhatsApp Contact", "WA-CONTACT-WIN", Exception("1062 Duplicate entry for mobile_no")
+        )
+        set_value_calls = []
+
+        with (
+            # 1st get_value -> None (no contact yet, take the insert path); 2nd (after the dup) -> winner.
+            patch.object(frappe.db, "get_value", side_effect=[None, winner]),
+            patch("frappe.get_doc", return_value=new_doc),
+            patch.object(frappe.db, "rollback") as mock_rollback,
+            patch.object(
+                frappe.db, "set_value", side_effect=lambda dt, name, vals: set_value_calls.append((name, vals))
+            ),
+            patch.object(frappe.db, "commit"),
+            patch("frappe.publish_realtime") as mock_publish,
+            patch("frappe.utils.now", return_value="2026-07-01 00:00:00"),
+        ):
+            update_contact_on_message(
+                mobile_no="9998887776",
+                message="hi",
+                message_type="Incoming",
+                profile_name="Cust",
+                is_outgoing=False,
+                owner="agent@x.com",
+                message_id="MSG-1",
+            )
+
+        new_doc.insert.assert_called_once()  # we attempted the insert
+        mock_rollback.assert_called_once()  # rolled back the failed insert before falling back
+        self.assertEqual(len(set_value_calls), 1, "took the existing-contact targeted update on the winner")
+        self.assertEqual(set_value_calls[0][0], "WA-CONTACT-WIN")
+        # Realtime still fires for the losing job, addressed to the winner's room/email.
+        mock_publish.assert_any_call("WA-CONTACT-WIN", ANY)
+        mock_publish.assert_any_call("latest_chat_updates", ANY, user="w@x.com")
+
+    def test_insert_race_reraises_when_no_winner_found(self):
+        # If the insert fails with UniqueValidationError but the re-lookup finds nothing (a genuine
+        # integrity error, not the race), re-raise instead of silently swallowing it as the race.
+        new_doc = MagicMock()
+        new_doc.insert.side_effect = frappe.UniqueValidationError(
+            "WhatsApp Contact", "WA-X", Exception("1062 Duplicate entry")
+        )
+
+        with (
+            patch.object(frappe.db, "get_value", side_effect=[None, None]),
+            patch("frappe.get_doc", return_value=new_doc),
+            patch.object(frappe.db, "rollback"),
+            patch("frappe.publish_realtime"),
+            patch("frappe.utils.now", return_value="2026-07-01 00:00:00"),
+            self.assertRaises(frappe.UniqueValidationError),
+        ):
+            update_contact_on_message(
+                mobile_no="9998887776",
+                message="hi",
+                message_type="Incoming",
+                profile_name="Cust",
+                is_outgoing=False,
+            )

--- a/whatsapp_chat/api/test_message.py
+++ b/whatsapp_chat/api/test_message.py
@@ -3,7 +3,10 @@ from unittest.mock import ANY, MagicMock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from whatsapp_chat.api.message import _update_contact_with_retry, update_contact_on_message
+from whatsapp_chat.api.message import (
+    _update_contact_with_retry,
+    update_contact_on_message,
+)
 
 
 class TestUpdateContactOnMessage(FrappeTestCase):
@@ -19,7 +22,9 @@ class TestUpdateContactOnMessage(FrappeTestCase):
         def flaky_set_value(*args, **kwargs):
             calls["n"] += 1
             if calls["n"] == 1:
-                raise frappe.QueryDeadlockError("1020 Record has changed in tabWhatsApp Contact")
+                raise frappe.QueryDeadlockError(
+                    "1020 Record has changed in tabWhatsApp Contact"
+                )
 
         with (
             patch.object(frappe.db, "set_value", side_effect=flaky_set_value),
@@ -58,13 +63,17 @@ class TestUpdateContactOnMessage(FrappeTestCase):
         # Structural change: an existing contact is updated via a blind set_value — NOT a get_doc + save
         # — so there is no read-modify-write to raise a 1020. Incoming clears is_read; profile_name that
         # matches the bare-number contact_name upgrades it; realtime uses the fetched name/email.
-        contact = frappe._dict({"name": "WA-CONTACT-1", "contact_name": "9998887776", "email": "a@x.com"})
+        contact = frappe._dict(
+            {"name": "WA-CONTACT-1", "contact_name": "9998887776", "email": "a@x.com"}
+        )
         set_value_calls = []
 
         with (
             patch.object(frappe.db, "get_value", return_value=contact),
             patch.object(
-                frappe.db, "set_value", side_effect=lambda dt, name, vals: set_value_calls.append((name, vals))
+                frappe.db,
+                "set_value",
+                side_effect=lambda dt, name, vals: set_value_calls.append((name, vals)),
             ),
             patch.object(frappe.db, "commit"),
             patch("frappe.get_doc") as mock_get_doc,
@@ -88,7 +97,11 @@ class TestUpdateContactOnMessage(FrappeTestCase):
         self.assertEqual(vals["last_message"], "hi")
         self.assertEqual(vals["message_type"], "Incoming")
         self.assertEqual(vals["is_read"], 0, "incoming clears is_read")
-        self.assertEqual(vals["contact_name"], "Cust", "profile_name upgrades a bare-number contact_name")
+        self.assertEqual(
+            vals["contact_name"],
+            "Cust",
+            "profile_name upgrades a bare-number contact_name",
+        )
         # Per-room publish + list-channel publish (email present) both fire with the fetched identifiers.
         mock_publish.assert_any_call("WA-CONTACT-1", ANY)
         mock_publish.assert_any_call("latest_chat_updates", ANY, user="a@x.com")
@@ -123,10 +136,14 @@ class TestUpdateContactOnMessage(FrappeTestCase):
         # our insert trips the mobile_no unique index (UniqueValidationError). We must roll back, re-look
         # up the winner's row, and take the existing-contact path (targeted set_value + realtime publish
         # with the winner's identifiers) — never crash the background job.
-        winner = frappe._dict({"name": "WA-CONTACT-WIN", "contact_name": "9998887776", "email": "w@x.com"})
+        winner = frappe._dict(
+            {"name": "WA-CONTACT-WIN", "contact_name": "9998887776", "email": "w@x.com"}
+        )
         new_doc = MagicMock()
         new_doc.insert.side_effect = frappe.UniqueValidationError(
-            "WhatsApp Contact", "WA-CONTACT-WIN", Exception("1062 Duplicate entry for mobile_no")
+            "WhatsApp Contact",
+            "WA-CONTACT-WIN",
+            Exception("1062 Duplicate entry for mobile_no"),
         )
         set_value_calls = []
 
@@ -136,7 +153,9 @@ class TestUpdateContactOnMessage(FrappeTestCase):
             patch("frappe.get_doc", return_value=new_doc),
             patch.object(frappe.db, "rollback") as mock_rollback,
             patch.object(
-                frappe.db, "set_value", side_effect=lambda dt, name, vals: set_value_calls.append((name, vals))
+                frappe.db,
+                "set_value",
+                side_effect=lambda dt, name, vals: set_value_calls.append((name, vals)),
             ),
             patch.object(frappe.db, "commit"),
             patch("frappe.publish_realtime") as mock_publish,
@@ -154,7 +173,11 @@ class TestUpdateContactOnMessage(FrappeTestCase):
 
         new_doc.insert.assert_called_once()  # we attempted the insert
         mock_rollback.assert_called_once()  # rolled back the failed insert before falling back
-        self.assertEqual(len(set_value_calls), 1, "took the existing-contact targeted update on the winner")
+        self.assertEqual(
+            len(set_value_calls),
+            1,
+            "took the existing-contact targeted update on the winner",
+        )
         self.assertEqual(set_value_calls[0][0], "WA-CONTACT-WIN")
         # Realtime still fires for the losing job, addressed to the winner's room/email.
         mock_publish.assert_any_call("WA-CONTACT-WIN", ANY)


### PR DESCRIPTION
…no dup race

TOCTOU: two concurrent default-queue jobs for the same new number both pass the get_value existence check and both insert, so the second trips the mobile_no unique index -> UniqueValidationError crashes the background job. The 07-01 fix (c9cabd3) only hardened the UPDATE branch; the insert was unguarded.

Wrap the insert in try/except UniqueValidationError: roll back, re-look-up the winner's row, and take the existing-contact path (targeted set_value + realtime publish) so the losing job still updates the contact and never crashes. Re-raise if no winner is found (a genuine integrity error, not the race). Covered by two mocked tests.